### PR TITLE
:bug: fix: incorrect arbitrary type for nested "content"

### DIFF
--- a/packages/types/tailwind.font/@content.ts
+++ b/packages/types/tailwind.font/@content.ts
@@ -1,10 +1,13 @@
 import { PlugBase, Pluggable } from "../plugin"
 import { TailwindArbitrary } from "../tailwind.common/@arbitrary"
 
-type TailwindContent<Plug extends PlugBase = ""> =
-    | "content-none"
+type TailwindContentVariants<Plug extends PlugBase = ""> =
+    | "none"
     | Pluggable<Plug>
     | TailwindArbitrary
+
+type TailwindContent<Plug extends PlugBase = ""> =
+    `content-${TailwindContentVariants<Plug>}`
 
 export type TailwindContentType<Plug extends PlugBase = ""> = {
     /**


### PR DESCRIPTION
Fix incorrect `"content"` nest type for arbitrary value

```ts
const fixed = wind({
       "::after": {
             content: "after:content-['some-content']"
       }
})
```