### PR TITLE
[fix] aria prefix is not applied at custom aria field

### DIFF
--- a/packages/tailwindest/src/tailwindest.nest.keys.ts
+++ b/packages/tailwindest/src/tailwindest.nest.keys.ts
@@ -98,40 +98,60 @@ export type TailwindNestConditionIdentifierOption = {
      */
     pseudoElementIdentifier: string
 }
-type TailwindNestConditions = {
+type TailwindestNestConditions = {
     break: string
     pseudoClass: string
     pseudoElement: string
 }
 
-type GetTailwindNestKeys<
-    NestConditions extends TailwindNestConditions,
+type GetTailwindestBaseNestKeys<
     IdentifierOption extends TailwindNestConditionIdentifierOption,
+    NestConditions extends TailwindestNestConditions,
 > =
     | `${IdentifierOption["breakIdentifier"]}${NestConditions["break"]}`
     | `${IdentifierOption["pseudoClassIdentifier"]}${NestConditions["pseudoClass"]}`
     | `${IdentifierOption["pseudoElementIdentifier"]}${NestConditions["pseudoElement"]}`
 
-type TailwindNestPluginOptions = {
+type GetTailwindestCustomScreenKeys<
+    IdentifierOption extends TailwindNestConditionIdentifierOption,
+    PluginOptions extends TailwindestNestPluginOptions,
+> = `${IdentifierOption["breakIdentifier"]}${Pluggable<
+    PluginOptions["screens"]
+>}`
+
+/**
+ * @description aria prefix of custom properties
+ * @example
+ * ```ts
+ * type MyAria = "checked" | "disabled"
+ * type Result = "aria-checked" | "aria-disabled"
+ * ```
+ */
+type ARIA_PREFIX = "aria-"
+
+type GetTailwindestCustomAriaKeys<
+    IdentifierOption extends TailwindNestConditionIdentifierOption,
+    PluginOptions extends TailwindestNestPluginOptions,
+> = `${IdentifierOption["breakIdentifier"]}${ARIA_PREFIX}${Pluggable<
+    PluginOptions["aria"]
+>}`
+
+type TailwindestNestPluginOptions = {
     screens: UndefinableString
     aria: UndefinableString
 }
 
 export type TailwindestNestKeys<
     IdentifierOption extends TailwindNestConditionIdentifierOption,
-    PluginOptions extends TailwindNestPluginOptions,
+    PluginOptions extends TailwindestNestPluginOptions,
 > =
-    | GetTailwindNestKeys<
+    | GetTailwindestBaseNestKeys<
+          IdentifierOption,
           {
               break: TailwindBreakConditions
               pseudoClass: TailwindPseudoClassConditions
               pseudoElement: TailwindPseudoElementConditions
-          },
-          IdentifierOption
+          }
       >
-    | `${IdentifierOption["breakIdentifier"]}${Pluggable<
-          PluginOptions["screens"]
-      >}`
-    | `${IdentifierOption["breakIdentifier"]}${Pluggable<
-          PluginOptions["aria"]
-      >}`
+    | GetTailwindestCustomScreenKeys<IdentifierOption, PluginOptions>
+    | GetTailwindestCustomAriaKeys<IdentifierOption, PluginOptions>


### PR DESCRIPTION
## Description

Add `aria-` prefix at custom Tailwindest aria option field.

```ts
type WithAria = Tailwindest<{}, {
    aria: "my1" | "my2"
}>

const x = createTools<WithAria>()

const box = x.style({
    "aria-my1": {
        "aria-my2": {
             backgroundColor: "aria-my1:aria-my2:bg-red-100"
        }
    }
})
```

Working as expected.

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass

close #71
