### PR TITLE
[fix] add missing vertical align property

### DIFF
--- a/packages/tailwindest/src/types/tailwind/properties/font/@vertical.align.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/font/@vertical.align.ts
@@ -1,3 +1,5 @@
+import type { TailwindArbitrary } from "../common/@arbitrary"
+
 type TailwindVerticalAlignVariants =
     | "baseline"
     | "top"
@@ -7,6 +9,7 @@ type TailwindVerticalAlignVariants =
     | "text-bottom"
     | "sub"
     | "super"
+    | TailwindArbitrary
 type TailwindVerticalAlign = `align-${TailwindVerticalAlignVariants}`
 export type TailwindVerticalAlignType = {
     /**

--- a/packages/tailwindest/src/types/tailwind/properties/font/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/font/index.ts
@@ -22,6 +22,7 @@ import { TailwindTextIndentType } from "./@text.indent"
 import { TailwindTextOverflowType } from "./@text.overflow"
 import { TailwindTextTransformType } from "./@text.transform"
 import { TailwindTextUnderlineOffsetType } from "./@text.underline.offset"
+import { TailwindVerticalAlignType } from "./@vertical.align"
 import { TailwindWhitespaceType } from "./@whitespace"
 
 export interface TailwindFont<
@@ -88,4 +89,5 @@ export interface TailwindFont<
         TailwindLineClampType<FontPlug["lineClamp"]>,
         TailwindHyphensType<FontPlug["hyphens"]>,
         TailwindListStylePositionType,
+        TailwindVerticalAlignType,
         TailwindWhitespaceType {}


### PR DESCRIPTION
## Description

1. `verticalAlign` is defined, but it is not included at tailwind font type. 
2. add arbitrary value support at `verticalAlign`.

```ts
const box = x.style({
    display: "flex",
    alignItems: "items-center",
    verticalAlign: "align-[4px]",
})
```

Thank you [@asheshook](https://github.com/asheswook) :)

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
