### PR TITLE
[feature-request] tailwindcss `v3.4`

### DIFF
--- a/packages/tailwindest/CHANGELOG.md
+++ b/packages/tailwindest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tailwindest
 
+## 2.3.0
+
+### Minor Changes
+
+-   Support tailwindcss v3.4
+
 ## 2.2.1
 
 ### Patch Changes

--- a/packages/tailwindest/package.json
+++ b/packages/tailwindest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tailwindest",
-    "version": "2.2.1",
+    "version": "2.3.0",
     "description": "typesafe, reusable tailwind",
     "homepage": "https://tailwindest.vercel.app",
     "author": "danpacho",

--- a/packages/tailwindest/src/tailwindest.nest.keys.ts
+++ b/packages/tailwindest/src/tailwindest.nest.keys.ts
@@ -1,7 +1,8 @@
-import { TailwindBreakConditions } from "./types/nest.keys/break"
-import { TailwindPseudoClassConditions } from "./types/nest.keys/pseudo.class"
-import { TailwindPseudoElementConditions } from "./types/nest.keys/pseudo.element"
-import { Pluggable } from "./types/plugin"
+import type { TailwindBreakConditions } from "./types/nest.keys/break"
+import type { TailwindGlobalConditions } from "./types/nest.keys/global"
+import type { TailwindPseudoClassConditions } from "./types/nest.keys/pseudo.class"
+import type { TailwindPseudoElementConditions } from "./types/nest.keys/pseudo.element"
+import type { Pluggable } from "./types/plugin"
 import type { UndefinableString } from "./utils"
 
 export type TailwindNestConditionIdentifierOption = {
@@ -145,6 +146,7 @@ export type TailwindestNestKeys<
     IdentifierOption extends TailwindNestConditionIdentifierOption,
     PluginOptions extends TailwindestNestPluginOptions,
 > =
+    | TailwindGlobalConditions
     | GetTailwindestBaseNestKeys<
           IdentifierOption,
           {

--- a/packages/tailwindest/src/tailwindest.short.ts
+++ b/packages/tailwindest/src/tailwindest.short.ts
@@ -22,6 +22,7 @@ type ShortTailwindestTypeSet<
     TailwindestExtendedNest<AllNestKeys, Tailwind, Identifier>
 
 /**
+ * @deprecated **No longer supported**
  * @description Short-handed version of `Tailwindest`
  * @description Add custom property, defined at `tailwind.config.js`
  * @see {@link https://tailwindcss.com/docs/configuration tailwind configuration}

--- a/packages/tailwindest/src/tailwindest.ts
+++ b/packages/tailwindest/src/tailwindest.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     TailwindNestConditionIdentifierOption,
     TailwindestNestKeys,
 } from "./tailwindest.nest.keys"
@@ -28,17 +28,22 @@ type TailwindestTypeSet<
  * // Plug customized type to createTools generic
  * type Custom = Tailwindest<
  *    {
- *        // Add color, sizing, screens global property
+ *        // Global style custom property
  *        color: "my-color1" | "my-color2"
  *        sizing: "0.25" | "0.5" | "0.75"
  *        screens: "@ipad" | "@iphone13pro" | "@iphone13proMax"
  *    },
  *    {
- *        // Add "emoji", "my-shadow1" & "my-shadow2"
+ *        // Specific style custom property
  *        listStyleType: "emoji"
  *        shadow: "my-shadow1" | "my-shadow2"
+ *    },
+ *    {
+ *        // Customize condition identifiers
+ *        breakIdentifier: "@",
+ *        pseudoClassIdentifier: ":",
+ *        pseudoElementIdentifier: "::",
  *    }
- * >
  *
  * export const tw = createTools<Custom>()
  * @description Pick specific type

--- a/packages/tailwindest/src/types/nest.keys/break.ts
+++ b/packages/tailwindest/src/types/nest.keys/break.ts
@@ -8,6 +8,7 @@ export type TailwindBreakConditions =
     | "print"
     | "rtl"
     | "ltr"
+    | "forced-colors"
     | "sm"
     | "md"
     | "lg"

--- a/packages/tailwindest/src/types/nest.keys/global.ts
+++ b/packages/tailwindest/src/types/nest.keys/global.ts
@@ -1,0 +1,1 @@
+export type TailwindGlobalConditions = "*"

--- a/packages/tailwindest/src/types/tailwind/plugin/tailwind.plugin.key.ts
+++ b/packages/tailwindest/src/types/tailwind/plugin/tailwind.plugin.key.ts
@@ -1,3 +1,20 @@
+import type {
+    TailwindBackgroundPlug,
+    TailwindBordersPlug,
+    TailwindEffectsPlug,
+    TailwindFiltersPlug,
+    TailwindFlexGridPlug,
+    TailwindFontPlug,
+    TailwindInteractivityPlug,
+    TailwindLayoutPlug,
+    TailwindSizingPlug,
+    TailwindSpacingPlug,
+    TailwindSvgPlug,
+    TailwindTablesPlug,
+    TailwindTransformsPlug,
+    TailwindTransitionAnimationPlug,
+} from "../properties"
+
 /**
  * @description Global style supported list
  * @see {@link https://tailwindcss.com/docs/theme#configuration-reference configuration reference}
@@ -9,106 +26,19 @@ export type TailwindGlobalPluginKey = "color" | "opacity" | "sizing"
  * @see {@link https://tailwindcss.com/docs/theme#configuration-reference configuration reference}
  */
 export type TailwindStylePluginKey =
+    // aria attributes
     | "aria"
-    | "accentColor"
-    | "animation"
-    | "aspectRatio"
-    | "backdropBlur"
-    | "backdropBrightness"
-    | "backdropContrast"
-    | "backdropGrayscale"
-    | "backdropHueRotate"
-    | "backdropInvert"
-    | "backdropOpacity"
-    | "backdropSaturate"
-    | "backdropSepia"
-    | "backgroundColor"
-    | "backgroundImage"
-    | "backgroundPosition"
-    | "backgroundSize"
-    | "blur"
-    | "brightness"
-    | "borderColor"
-    | "borderRadius"
-    | "borderSpacing"
-    | "borderWidth"
-    | "boxShadow"
-    | "boxShadowColor"
-    | "columns"
-    | "caretColor"
-    | "contrast"
-    | "content"
-    | "cursor"
-    | "divideColor"
-    | "divideWidth"
-    | "dropShadow"
-    | "fill"
-    | "grayscale"
-    | "hueRotate"
-    | "hyphens"
-    | "invert"
-    | "flex"
-    | "flexBasis"
-    | "flexGrow"
-    | "flexShrink"
-    | "fontFamily"
-    | "fontSize"
-    | "fontWeight"
-    | "gap"
-    | "gradientColorStops"
-    | "gridAutoColumns"
-    | "gridAutoRows"
-    | "gridColumn"
-    | "gridColumnEnd"
-    | "gridColumnStart"
-    | "gridRow"
-    | "gridRowStart"
-    | "gridRowEnd"
-    | "gridTemplateColumns"
-    | "gridTemplateRows"
-    | "height"
-    | "inset"
-    | "letterSpacing"
-    | "lineHeight"
-    | "lineClamp"
-    | "listStyleType"
-    | "listStyleImage"
-    | "margin"
-    | "maxHeight"
-    | "maxWidth"
-    | "minHeight"
-    | "minWidth"
-    | "objectPosition"
-    | "order"
-    | "padding"
-    | "outlineColor"
-    | "outlineOffset"
-    | "outlineWidth"
-    | "ringColor"
-    | "ringOffsetColor"
-    | "ringOffsetWidth"
-    | "ringWidth"
-    | "rotate"
-    | "saturate"
-    | "scale"
-    | "scrollMargin"
-    | "scrollPadding"
-    | "sepia"
-    | "skew"
-    | "space"
-    | "stroke"
-    | "strokeWidth"
-    | "textColor"
-    | "textDecorationColor"
-    | "textDecorationThickness"
-    | "textUnderlineOffset"
-    | "textIndent"
-    | "transformOrigin"
-    | "transitionDelay"
-    | "transitionDuration"
-    | "transitionProperty"
-    | "transitionTimingFunction"
-    | "translate"
-    | "width"
-    | "willChange"
-    | "zIndex"
+    | Exclude<keyof TailwindBackgroundPlug, "gradientColorStops">
+    | keyof TailwindTransitionAnimationPlug
+    | keyof TailwindTransformsPlug
+    | keyof TailwindTablesPlug
+    | keyof TailwindSvgPlug
+    | keyof TailwindSpacingPlug
+    | keyof TailwindLayoutPlug
+    | keyof TailwindBordersPlug
+    | keyof TailwindEffectsPlug
+    | keyof TailwindFiltersPlug
+    | keyof TailwindFlexGridPlug
+    | keyof TailwindFontPlug
+    | keyof TailwindInteractivityPlug
+    | keyof TailwindSizingPlug

--- a/packages/tailwindest/src/types/tailwind/properties/accessibility/@forced.color.adjust.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/accessibility/@forced.color.adjust.ts
@@ -1,0 +1,8 @@
+type TailwindForcedColorAdjust = "auto" | "none"
+export type TailwindForcedColorAdjustType = {
+    /**
+     *@description Utilities for opting in and out of forced colors.
+     *@see {@link https://tailwindcss.com/docs/forced-color-adjust forced color adjust}
+     */
+    forcedColorAdjust: `forced-color-adjust-${TailwindForcedColorAdjust}`
+}

--- a/packages/tailwindest/src/types/tailwind/properties/accessibility/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/accessibility/index.ts
@@ -1,3 +1,6 @@
+import { TailwindForcedColorAdjustType } from "./@forced.color.adjust"
 import { TailwindScreenReadersType } from "./@screen.readers"
 
-export type TailwindAccessibility = TailwindScreenReadersType
+export interface TailwindAccessibility
+    extends TailwindScreenReadersType,
+        TailwindForcedColorAdjustType {}

--- a/packages/tailwindest/src/types/tailwind/properties/backgrounds/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/backgrounds/index.ts
@@ -9,15 +9,17 @@ import { TailwindBackgroundSizeType } from "./@background.size"
 import { TailwindBackgroundImageType } from "./@gradient"
 import { TailwindGradientColorStopsType } from "./@gradient.color.stops"
 
+export interface TailwindBackgroundPlug {
+    backgroundSize?: string
+    backgroundColor?: string
+    backgroundImage?: string
+    backgroundPosition?: string
+    gradientColorStops?: string
+}
+
 export interface TailwindBackgrounds<
     TailwindColor extends string,
-    BackgroundsPlug extends {
-        backgroundSize?: string
-        backgroundColor?: string
-        backgroundImage?: string
-        backgroundPosition?: string
-        gradientColorStops?: string
-    } = {
+    BackgroundsPlug extends TailwindBackgroundPlug = {
         backgroundSize: ""
         backgroundColor: ""
         backgroundImage: ""

--- a/packages/tailwindest/src/types/tailwind/properties/borders/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/borders/index.ts
@@ -21,22 +21,24 @@ import { TailwindRingOffsetColorType } from "./@ring.offset.color"
 import { TailwindRingOffsetWidthType } from "./@ring.offset.width"
 import { TailwindRingWidthType } from "./@ring.width"
 
+export interface TailwindBordersPlug {
+    borderColor?: string
+    borderRadius?: string
+    borderWidth?: string
+    divideColor?: string
+    divideWidth?: string
+    outlineColor?: string
+    outlineOffset?: string
+    outlineWidth?: string
+    ringOffsetColor?: string
+    ringOffsetWidth?: string
+    ringColor?: string
+    ringWidth?: string
+}
+
 export interface TailwindBorders<
     TailwindColor extends string,
-    BordersPlug extends {
-        borderColor?: string
-        borderRadius?: string
-        borderWidth?: string
-        divideColor?: string
-        divideWidth?: string
-        outlineColor?: string
-        outlineOffset?: string
-        outlineWidth?: string
-        ringOffsetColor?: string
-        ringOffsetWidth?: string
-        ringColor?: string
-        ringWidth?: string
-    } = {
+    BordersPlug extends TailwindBordersPlug = {
         borderColor: ""
         borderRadius: ""
         borderWidth: ""

--- a/packages/tailwindest/src/types/tailwind/properties/effects/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/effects/index.ts
@@ -4,6 +4,11 @@ import { TailwindBoxShadowColorType } from "./@box.shadow.color"
 import { TailwindMixBlendModeType } from "./@mix.blend.mode"
 import { TailwindOpacityType } from "./@opacity"
 
+export interface TailwindEffectsPlug {
+    boxShadow?: string
+    boxShadowColor?: string
+}
+
 export interface TailwindEffects<
     TailwindColor extends string,
     TailwindOpacity extends string,

--- a/packages/tailwindest/src/types/tailwind/properties/filters/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/filters/index.ts
@@ -1,4 +1,3 @@
-import { PluginOption } from "../../../plugin"
 import { TailwindBackdropOpacityType } from "./@backdrop.opacity"
 import { TailwindBackdropBlurType, TailwindBlurType } from "./@blur"
 import {
@@ -19,32 +18,48 @@ import { TailwindBackdropInvertType, TailwindInvertType } from "./@invert"
 import { TailwindBackdropSaturateType, TailwindSaturateType } from "./@saturate"
 import { TailwindBackdropSepiaType, TailwindSepiaType } from "./@sepia"
 
-type FiltersPluginKey =
-    | "dropShadow"
-    | "blur"
-    | "contrast"
-    | "grayscale"
-    | "hueRotate"
-    | "invert"
-    | "opacity"
-    | "saturate"
-    | "sepia"
-    | "backdropBrightness"
-    | "backdropBlur"
-    | "backdropContrast"
-    | "backdropGrayscale"
-    | "backdropHueRotate"
-    | "backdropInvert"
-    | "backdropOpacity"
-    | "backdropSaturate"
-    | "backdropSepia"
-    | "brightness"
+export interface TailwindFiltersPlug {
+    dropShadow?: string
+    blur?: string
+    contrast?: string
+    grayscale?: string
+    hueRotate?: string
+    invert?: string
+    saturate?: string
+    sepia?: string
+    backdropBrightness?: string
+    backdropBlur?: string
+    backdropContrast?: string
+    backdropGrayscale?: string
+    backdropHueRotate?: string
+    backdropInvert?: string
+    backdropOpacity?: string
+    backdropSaturate?: string
+    backdropSepia?: string
+    brightness?: string
+}
 
 export interface TailwindFilters<
-    FiltersPlug extends PluginOption<FiltersPluginKey> = PluginOption<
-        FiltersPluginKey,
-        ""
-    >,
+    FiltersPlug extends TailwindFiltersPlug = {
+        dropShadow: ""
+        blur: ""
+        contrast: ""
+        grayscale: ""
+        hueRotate: ""
+        invert: ""
+        saturate: ""
+        sepia: ""
+        backdropBrightness: ""
+        backdropBlur: ""
+        backdropContrast: ""
+        backdropGrayscale: ""
+        backdropHueRotate: ""
+        backdropInvert: ""
+        backdropOpacity: ""
+        backdropSaturate: ""
+        backdropSepia: ""
+        brightness: ""
+    },
 > extends TailwindBlurType<FiltersPlug["blur"]>,
         TailwindBrightnessType<FiltersPlug["brightness"]>,
         TailwindContrastType<FiltersPlug["contrast"]>,

--- a/packages/tailwindest/src/types/tailwind/properties/flex.grid/@grid.template.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/flex.grid/@grid.template.ts
@@ -1,7 +1,8 @@
 import { PlugBase, Pluggable } from "../../../plugin"
 import { TailwindArbitrary } from "../common/@arbitrary"
 
-type TailwindGridTemplateRowsVariants<Plug extends PlugBase = ""> =
+type TailwindGridTemplateVariants<Plug extends PlugBase = ""> = Pluggable<
+    | "subgrid"
     | "none"
     | "1"
     | "2"
@@ -9,11 +10,18 @@ type TailwindGridTemplateRowsVariants<Plug extends PlugBase = ""> =
     | "4"
     | "5"
     | "6"
-    | Pluggable<Plug>
+    | "7"
+    | "8"
+    | "9"
+    | "10"
+    | "11"
+    | "12"
+    | Plug
     | TailwindArbitrary
+>
 
 type TailwindGridTemplateRows<Plug extends PlugBase = ""> =
-    `grid-rows-${TailwindGridTemplateRowsVariants<Plug>}`
+    `grid-rows-${TailwindGridTemplateVariants<Plug>}`
 export type TailwindGridTemplateRowsType<Plug extends PlugBase = ""> = {
     /**
      *@description Utilities for specifying the rows in a grid layout.
@@ -22,27 +30,8 @@ export type TailwindGridTemplateRowsType<Plug extends PlugBase = ""> = {
     gridTemplateRows: TailwindGridTemplateRows<Plug>
 }
 
-type TailwindGridTemplateColumnsVariants<Plug extends PlugBase = ""> =
-    Pluggable<
-        | "none"
-        | "1"
-        | "2"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "10"
-        | "11"
-        | "12"
-        | Plug
-        | TailwindArbitrary
-    >
-
 type TailwindGridTemplateColumns<Plug extends PlugBase = ""> =
-    `grid-cols-${TailwindGridTemplateColumnsVariants<Plug>}`
+    `grid-cols-${TailwindGridTemplateVariants<Plug>}`
 export type TailwindGridTemplateColumnsType<Plug extends PlugBase = ""> = {
     /**
      *@description Utilities for specifying the columns in a grid layout.

--- a/packages/tailwindest/src/types/tailwind/properties/flex.grid/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/flex.grid/index.ts
@@ -45,12 +45,13 @@ import {
     TailwindGridTemplateRowsType,
 } from "./@grid.template"
 
+interface TailwindFlexGridCommonPlug {
+    gap?: string
+    order?: string
+}
 export interface TailwindFlexGridCommon<
     TailwindSpacing extends string,
-    FlexGridCommonPlug extends {
-        gap?: string
-        order?: string
-    } = {
+    FlexGridCommonPlug extends TailwindFlexGridCommonPlug = {
         gap: ""
         order: ""
     },
@@ -63,14 +64,16 @@ export interface TailwindFlexGridCommon<
             TailwindSpacing | Pluggable<FlexGridCommonPlug["gap"]>
         > {}
 
+interface TailwindFlexPlug {
+    flex?: string
+    flexBasis?: string
+    flexGrow?: string
+    flexShrink?: string
+}
+
 export interface TailwindFlex<
     TailwindSpacing extends string,
-    FlexPlug extends {
-        flex?: string
-        flexBasis?: string
-        flexGrow?: string
-        flexShrink?: string
-    } = {
+    FlexPlug extends TailwindFlexPlug = {
         flex: ""
         flexBasis: ""
         flexGrow: ""
@@ -83,19 +86,21 @@ export interface TailwindFlex<
         TailwindFlexShrinkType<FlexPlug["flexShrink"]>,
         TailwindFlexBasisType<TailwindSpacing, FlexPlug["flexBasis"]> {}
 
+interface TailwindGridPlug {
+    gridAutoColumns?: string
+    gridAutoRows?: string
+    gridColumn?: string
+    gridColumnStart?: string
+    gridColumnEnd?: string
+    gridRow?: string
+    gridRowEnd?: string
+    gridRowStart?: string
+    gridTemplateColumns?: string
+    gridTemplateRows?: string
+}
+
 export interface TailwindGrid<
-    GridPlug extends {
-        gridAutoColumns?: string
-        gridAutoRows?: string
-        gridColumn?: string
-        gridColumnStart?: string
-        gridColumnEnd?: string
-        gridRow?: string
-        gridRowEnd?: string
-        gridRowStart?: string
-        gridTemplateColumns?: string
-        gridTemplateRows?: string
-    } = {
+    GridPlug extends TailwindGridPlug = {
         gridAutoColumns: ""
         gridAutoRows: ""
         gridColumn: ""
@@ -123,3 +128,8 @@ export interface TailwindGrid<
         TailwindGridAutoColumnsType<GridPlug["gridAutoColumns"]>,
         TailwindGridTemplateRowsType<GridPlug["gridTemplateRows"]>,
         TailwindGridTemplateColumnsType<GridPlug["gridTemplateColumns"]> {}
+
+export interface TailwindFlexGridPlug
+    extends TailwindFlexGridCommonPlug,
+        TailwindFlexPlug,
+        TailwindGridPlug {}

--- a/packages/tailwindest/src/types/tailwind/properties/font/@text.wrap.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/font/@text.wrap.ts
@@ -1,0 +1,8 @@
+type TailwindTextWrap = "wrap" | "nowrap" | "balance" | "pretty"
+export type TailwindTextWrapType = {
+    /**
+     *@description Utilities for controlling how text wraps within an element.
+     *@see {@link https://tailwindcss.com/docs/text-wrap text wrap}
+     */
+    textWrap: `text-${TailwindTextWrap}`
+}

--- a/packages/tailwindest/src/types/tailwind/properties/font/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/font/index.ts
@@ -22,28 +22,31 @@ import { TailwindTextIndentType } from "./@text.indent"
 import { TailwindTextOverflowType } from "./@text.overflow"
 import { TailwindTextTransformType } from "./@text.transform"
 import { TailwindTextUnderlineOffsetType } from "./@text.underline.offset"
+import { TailwindTextWrapType } from "./@text.wrap"
 import { TailwindVerticalAlignType } from "./@vertical.align"
 import { TailwindWhitespaceType } from "./@whitespace"
 
+export interface TailwindFontPlug {
+    content?: string
+    fontFamily?: string
+    fontSize?: string
+    fontWeight?: string
+    textColor?: string
+    textIndent?: string
+    textDecorationColor?: string
+    textDecorationThickness?: string
+    textUnderlineOffset?: string
+    letterSpacing?: string
+    lineHeight?: string
+    lineClamp?: string
+    listStyleType?: string
+    listStyleImage?: string
+    hyphens?: string
+}
+
 export interface TailwindFont<
     TailwindColor extends string,
-    FontPlug extends {
-        content?: string
-        fontFamily?: string
-        fontSize?: string
-        fontWeight?: string
-        textColor?: string
-        textIndent?: string
-        textDecorationColor?: string
-        textDecorationThickness?: string
-        textUnderlineOffset?: string
-        letterSpacing?: string
-        lineHeight?: string
-        lineClamp?: string
-        listStyleType?: string
-        listStyleImage?: string
-        hyphens?: string
-    } = {
+    FontPlug extends TailwindFontPlug = {
         content: ""
         fontFamily: ""
         fontSize: ""
@@ -60,7 +63,8 @@ export interface TailwindFont<
         listStyleImage: ""
         hyphens: ""
     },
-> extends TailwindTextAlignType,
+> extends TailwindTextWrapType,
+        TailwindTextAlignType,
         TailwindTextOverflowType,
         TailwindTextTransformType,
         TailwindTextDecorationType,

--- a/packages/tailwindest/src/types/tailwind/properties/interactivity/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/interactivity/index.ts
@@ -15,17 +15,19 @@ import { TailwindTouchActionType } from "./@touch.action"
 import { TailwindUserSelectType } from "./@user.select"
 import { TailwindWillChangeType } from "./@will.change"
 
+export interface TailwindInteractivityPlug {
+    cursor?: string
+    willChange?: string
+    caretColor?: string
+    accentColor?: string
+    scrollMargin?: string
+    scrollPadding?: string
+}
+
 export interface TailwindInteractivity<
     TailwindColor extends string,
     TailwindSpacing extends string,
-    InteractivityPlug extends {
-        cursor?: string
-        willChange?: string
-        caretColor?: string
-        accentColor?: string
-        scrollMargin?: string
-        scrollPadding?: string
-    } = {
+    InteractivityPlug extends TailwindInteractivityPlug = {
         cursor: ""
         willChange: ""
         caretColor: ""

--- a/packages/tailwindest/src/types/tailwind/properties/layout/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/layout/index.ts
@@ -17,15 +17,17 @@ import { TailwindPositionType, TailwindPositionValueType } from "./@position"
 import { TailwindVisibilityType } from "./@visibility"
 import { TailwindZIndexType } from "./@z.index"
 
+export interface TailwindLayoutPlug {
+    inset?: string
+    zIndex?: string
+    columns?: string
+    aspectRatio?: string
+    objectPosition?: string
+}
+
 export interface TailwindLayout<
     GlobalPlug extends string,
-    LayoutPlug extends {
-        inset?: string
-        zIndex?: string
-        columns?: string
-        aspectRatio?: string
-        objectPosition?: string
-    } = {
+    LayoutPlug extends TailwindLayoutPlug = {
         inset: ""
         zIndex: ""
         columns: ""

--- a/packages/tailwindest/src/types/tailwind/properties/sizing/@height.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/sizing/@height.ts
@@ -1,6 +1,8 @@
 import { PlugBase, Pluggable } from "../../../plugin"
 import { MinSizingVariants, SizingVariants } from "./@sizing.variants"
 
+type HeightFeature = "svh" | "lvh" | "dvh"
+
 type TailwindHeightVariants<TailwindSpacing extends string> =
     | SizingVariants<TailwindSpacing>
     | "1/2"
@@ -27,20 +29,31 @@ export type TailwindHeightType<
      *@unit Gap `1` = `4px` = `0.25rem`
      *@see {@link https://tailwindcss.com/docs/height height}
      */
-    height: `h-${TailwindHeightVariants<TailwindSpacing> | Pluggable<Plug>}`
+    height: `h-${
+        | TailwindHeightVariants<TailwindSpacing>
+        | HeightFeature
+        | Pluggable<Plug>}`
 }
 
-type TailwindMinHeight<Plug extends PlugBase = ""> = `min-h-${
+type TailwindMinHeight<
+    TailwindSpacing extends string,
+    Plug extends PlugBase = "",
+> = `min-h-${
     | "screen"
     | MinSizingVariants
+    | TailwindSpacing
+    | HeightFeature
     | Pluggable<Plug>}`
-export type TailwindMinHeightType<Plug extends PlugBase = ""> = {
+export type TailwindMinHeightType<
+    TailwindSpacing extends string,
+    Plug extends PlugBase = "",
+> = {
     /**
      *@description Utilities for setting the minimum height of an element.
      *@unit Gap `1` = `4px` = `0.25rem`
      *@see {@link https://tailwindcss.com/docs/min-height min-height}
      */
-    minHeight: TailwindMinHeight<Plug>
+    minHeight: TailwindMinHeight<TailwindSpacing, Plug>
 }
 
 export type TailwindMaxHeightType<
@@ -55,5 +68,6 @@ export type TailwindMaxHeightType<
     maxHeight: `max-h-${
         | "screen"
         | Exclude<SizingVariants<TailwindSpacing>, "auto">
+        | HeightFeature
         | Pluggable<Plug>}`
 }

--- a/packages/tailwindest/src/types/tailwind/properties/sizing/@size.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/sizing/@size.ts
@@ -1,0 +1,47 @@
+import { PlugBase, Pluggable } from "../../../plugin"
+
+type TailwindSizeVariants<TailwindSpacing extends string> =
+    | "1/2"
+    | "1/3"
+    | "2/3"
+    | "1/4"
+    | "2/4"
+    | "3/4"
+    | "1/5"
+    | "2/5"
+    | "3/5"
+    | "4/5"
+    | "1/6"
+    | "2/6"
+    | "3/6"
+    | "4/6"
+    | "5/6"
+    | "1/12"
+    | "2/12"
+    | "3/12"
+    | "4/12"
+    | "5/12"
+    | "6/12"
+    | "7/12"
+    | "8/12"
+    | "9/12"
+    | "10/12"
+    | "11/12"
+    | "auto"
+    | "full"
+    | "min"
+    | "max"
+    | "fit"
+    | TailwindSpacing
+
+export type TailwindSizeType<
+    TailwindSpacing extends string,
+    Plug extends PlugBase = "",
+> = {
+    /**
+     *@description Utilities for setting the `width` and `height` of an element at the same time.
+     *@unit Gap `1` = `4px` = `0.25rem`
+     *@see {@link https://tailwindcss.com/docs/size size}
+     */
+    size: `size-${TailwindSizeVariants<TailwindSpacing> | Pluggable<Plug>}`
+}

--- a/packages/tailwindest/src/types/tailwind/properties/sizing/@width.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/sizing/@width.ts
@@ -1,5 +1,4 @@
 import { PlugBase, Pluggable } from "../../../plugin"
-import { TailwindArbitrary } from "../common/@arbitrary"
 import { MinSizingVariants, SizingVariants } from "./@sizing.variants"
 
 type TailwindSizingVariants<TailwindSpacing extends string> =
@@ -41,20 +40,23 @@ export type TailwindWidthType<
     width: `w-${TailwindSizingVariants<TailwindSpacing> | Pluggable<Plug>}`
 }
 
-type TailwindMinWidth<Plug extends PlugBase = ""> = `min-w-${
-    | MinSizingVariants
-    | Pluggable<Plug>}`
-export type TailwindMinWidthType<Plug extends PlugBase = ""> = {
+type TailwindMinWidth<
+    TailwindSpacing extends string,
+    Plug extends PlugBase = "",
+> = `min-w-${MinSizingVariants | TailwindSpacing | Pluggable<Plug>}`
+export type TailwindMinWidthType<
+    TailwindSpacing extends string,
+    Plug extends PlugBase = "",
+> = {
     /**
      *@description Utilities for setting the minimum width of an element.
      *@unit Gap `1` = `4px` = `0.25rem`
      *@see {@link https://tailwindcss.com/docs/min-width min-width}
      */
-    minWidth: TailwindMinWidth<Plug>
+    minWidth: TailwindMinWidth<TailwindSpacing, Plug>
 }
 
-type TailwindMaxWidthVariants<Plug extends PlugBase = ""> = Pluggable<
-    | "0"
+type TailwindMaxWidthVariants<TailwindSpacing extends string> =
     | "none"
     | "xs"
     | "sm"
@@ -77,17 +79,20 @@ type TailwindMaxWidthVariants<Plug extends PlugBase = ""> = Pluggable<
     | "screen-lg"
     | "screen-xl"
     | "screen-2xl"
-    | Plug
-    | TailwindArbitrary
->
+    | TailwindSpacing
 
-type TailwindMaxWidth<Plug extends PlugBase = ""> =
-    `max-w-${TailwindMaxWidthVariants<Plug>}`
-export type TailwindMaxWidthType<Plug extends PlugBase = ""> = {
+type TailwindMaxWidth<
+    TailwindSpacing extends string,
+    Plug extends PlugBase = "",
+> = `max-w-${TailwindMaxWidthVariants<TailwindSpacing> | Pluggable<Plug>}`
+export type TailwindMaxWidthType<
+    TailwindSpacing extends string,
+    Plug extends PlugBase = "",
+> = {
     /**
      *@description Utilities for setting the maximum width of an element.
      *@unit Gap `1` = `4px` = `0.25rem`
      *@see {@link https://tailwindcss.com/docs/max-width max-width}
      */
-    maxWidth: TailwindMaxWidth<Plug>
+    maxWidth: TailwindMaxWidth<TailwindSpacing, Plug>
 }

--- a/packages/tailwindest/src/types/tailwind/properties/sizing/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/sizing/index.ts
@@ -3,22 +3,27 @@ import {
     TailwindMaxHeightType,
     TailwindMinHeightType,
 } from "./@height"
+import { TailwindSizeType } from "./@size"
 import {
     TailwindMaxWidthType,
     TailwindMinWidthType,
     TailwindWidthType,
 } from "./@width"
 
+export interface TailwindSizingPlug {
+    size?: string
+    width?: string
+    maxWidth?: string
+    minWidth?: string
+    height?: string
+    maxHeight?: string
+    minHeight?: string
+}
+
 export interface TailwindSizing<
     TailwindSpacing extends string,
-    SizingPlug extends {
-        width?: string
-        maxWidth?: string
-        minWidth?: string
-        height?: string
-        maxHeight?: string
-        minHeight?: string
-    } = {
+    SizingPlug extends TailwindSizingPlug = {
+        size: ""
         width: ""
         maxWidth: ""
         minWidth: ""
@@ -26,9 +31,12 @@ export interface TailwindSizing<
         maxHeight: ""
         minHeight: ""
     },
-> extends TailwindMinHeightType<SizingPlug["minHeight"]>,
+> extends TailwindSizeType<TailwindSpacing, SizingPlug["size"]>,
+        // height
         TailwindHeightType<TailwindSpacing, SizingPlug["height"]>,
+        TailwindMinHeightType<TailwindSpacing, SizingPlug["minHeight"]>,
         TailwindMaxHeightType<TailwindSpacing, SizingPlug["maxHeight"]>,
-        TailwindMinWidthType<SizingPlug["minWidth"]>,
-        TailwindMaxWidthType<SizingPlug["maxHeight"]>,
-        TailwindWidthType<TailwindSpacing, SizingPlug["width"]> {}
+        // width
+        TailwindWidthType<TailwindSpacing, SizingPlug["width"]>,
+        TailwindMinWidthType<TailwindSpacing, SizingPlug["minWidth"]>,
+        TailwindMaxWidthType<TailwindSpacing, SizingPlug["maxWidth"]> {}

--- a/packages/tailwindest/src/types/tailwind/properties/sizing/short/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/sizing/short/index.ts
@@ -1,3 +1,4 @@
+import { TailwindSizingPlug } from ".."
 import {
     ShortTailwindHeightType,
     ShortTailwindMaxHeightType,
@@ -11,14 +12,8 @@ import {
 
 export interface ShortTailwindSizing<
     TailwindSpacing extends string,
-    SizingPlug extends {
-        width?: string
-        maxWidth?: string
-        minWidth?: string
-        height?: string
-        maxHeight?: string
-        minHeight?: string
-    } = {
+    SizingPlug extends TailwindSizingPlug = {
+        size: ""
         width: ""
         maxWidth: ""
         minWidth: ""

--- a/packages/tailwindest/src/types/tailwind/properties/spacing/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/spacing/index.ts
@@ -3,13 +3,14 @@ import { TailwindMarginType } from "./@margin"
 import { TailwindPaddingType } from "./@padding"
 import { TailwindSpaceType } from "./@space.between"
 
+export interface TailwindSpacingPlug {
+    padding?: string
+    margin?: string
+    space?: string
+}
 export interface TailwindSpacing<
     TailwindSpacing extends string,
-    SpacingPlug extends {
-        padding?: string
-        margin?: string
-        space?: string
-    } = {
+    SpacingPlug extends TailwindSpacingPlug = {
         padding: ""
         margin: ""
         space: ""

--- a/packages/tailwindest/src/types/tailwind/properties/svg/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/svg/index.ts
@@ -2,6 +2,12 @@ import { TailwindFillType } from "./@fill"
 import { TailwindStrokeType } from "./@stroke"
 import { TailwindStrokeWidthType } from "./@stroke.width"
 
+export interface TailwindSvgPlug {
+    fill?: string
+    stroke?: string
+    strokeWidth?: string
+}
+
 export interface TailwindSvg<
     TailwindColor extends string,
     SvgPlug extends {

--- a/packages/tailwindest/src/types/tailwind/properties/tables/@border.spacing.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/tables/@border.spacing.ts
@@ -1,19 +1,19 @@
 import { PluginVariants } from "../../../plugin"
 
-export type TailwindBorderSpacingType<BorderSpacing extends string> = {
+export type TailwindBorderSpacingType<TailwindSpacing extends string> = {
     /**
      *@description Utilities for controlling the spacing between table borders.
      *@see {@link https://tailwindcss.com/docs/border-spacing border-spacing}
      */
-    borderSpacing: PluginVariants<"border-spacing", BorderSpacing>
+    borderSpacing: PluginVariants<"border-spacing", TailwindSpacing>
     /**
      *@description Utilities for controlling the spacing between table borders x direction.
      *@see {@link https://tailwindcss.com/docs/border-spacing border-spacing-x}
      */
-    borderSpacingX: PluginVariants<"border-spacing-x", BorderSpacing>
+    borderSpacingX: PluginVariants<"border-spacing-x", TailwindSpacing>
     /**
      *@description Utilities for controlling the spacing between table borders y direction.
      *@see {@link https://tailwindcss.com/docs/border-spacing border-spacing-y}
      */
-    borderSpacingY: PluginVariants<"border-spacing-y", BorderSpacing>
+    borderSpacingY: PluginVariants<"border-spacing-y", TailwindSpacing>
 }

--- a/packages/tailwindest/src/types/tailwind/properties/tables/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/tables/index.ts
@@ -1,10 +1,20 @@
+import { Pluggable } from "../../../plugin"
 import { TailwindBorderCollapseType } from "./@border.collapse"
 import { TailwindBorderSpacingType } from "./@border.spacing"
 import { TailwindCaptionSideType } from "./@caption.side"
 import { TailwindTableLayoutType } from "./@table.layout"
 
-export interface TailwindTables<TailwindSpacing extends string>
-    extends TailwindBorderCollapseType,
-        TailwindBorderSpacingType<TailwindSpacing>,
+export interface TailwindTablesPlug {
+    borderSpacing?: string
+}
+export interface TailwindTables<
+    TailwindSpacing extends string,
+    TablesPlug extends TailwindTablesPlug = {
+        borderSpacing: ""
+    },
+> extends TailwindBorderCollapseType,
+        TailwindBorderSpacingType<
+            TailwindSpacing | Pluggable<TablesPlug["borderSpacing"]>
+        >,
         TailwindTableLayoutType,
         TailwindCaptionSideType {}

--- a/packages/tailwindest/src/types/tailwind/properties/transforms/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/transforms/index.ts
@@ -39,15 +39,17 @@ type TailwindTranslateVariants =
     | "full"
     | TailwindArbitrary
 
+export interface TailwindTransformsPlug {
+    skew?: string
+    scale?: string
+    rotate?: string
+    translate?: string
+    transformOrigin?: string
+}
+
 export interface TailwindTransforms<
     TailwindSpacing extends string,
-    TransformsPlug extends {
-        skew?: string
-        scale?: string
-        rotate?: string
-        translate?: string
-        transformOrigin?: string
-    } = {
+    TransformsPlug extends TailwindTransformsPlug = {
         skew: ""
         scale: ""
         rotate: ""

--- a/packages/tailwindest/src/types/tailwind/properties/transition.animation/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/transition.animation/index.ts
@@ -41,14 +41,16 @@ type TailwindTransitionDelayVariants =
     | "1000"
     | TailwindArbitrary
 
+export interface TailwindTransitionAnimationPlug {
+    animation?: string
+    transitionDelay?: string
+    transitionDuration?: string
+    transitionProperty?: string
+    transitionTimingFunction?: string
+}
+
 export interface TailwindTransitionAnimation<
-    TransitionAnimationPlug extends {
-        animation?: string
-        transitionDelay?: string
-        transitionDuration?: string
-        transitionProperty?: string
-        transitionTimingFunction?: string
-    } = {
+    TransitionAnimationPlug extends TailwindTransitionAnimationPlug = {
         animation: ""
         transitionDelay: ""
         transitionDuration: ""

--- a/scripts/build.class.js
+++ b/scripts/build.class.js
@@ -54,6 +54,7 @@ const MEDIA_CONDITIONS = [
     "print",
     "rtl",
     "ltr",
+    "forced-colors",
 ]
 
 const SCREEN_CONDITIONS = [
@@ -79,6 +80,8 @@ const ARIA_CONDITIONS = [
     "aria-required",
     "aria-selected",
 ]
+
+const CHILD_CONDITIONS = ["*"]
 
 const THEME_CONDITION = ["dark"]
 
@@ -137,6 +140,11 @@ const buildData = [
         fileName: "pseudo.element",
         typeName: "TailwindPseudoElementConditions",
         types: PSEUDO_ELEMENTS,
+    },
+    {
+        fileName: "global",
+        typeName: "TailwindGlobalConditions",
+        types: CHILD_CONDITIONS,
     },
 ]
 


### PR DESCRIPTION
## Description

### 1. 🔮 **Add support for tailwindcss `v3.4`**

1. Support [New size-* utilities](https://tailwindcss.com/blog/tailwindcss-v3-4#new-size-utilities)
2. Support [Dynamic viewport units](https://tailwindcss.com/blog/tailwindcss-v3-4#dynamic-viewport-units)
3. Support [Style children with the * variant](https://tailwindcss.com/blog/tailwindcss-v3-4#style-children-with-the-variant)
4. Support [Subgrid support](https://tailwindcss.com/blog/tailwindcss-v3-4#subgrid-support)
5. Support [Extended min-width, max-width, and min-height scales](https://tailwindcss.com/blog/tailwindcss-v3-4#extended-min-width-max-width-and-min-height-scales)
6. Support [Extended opacity scale](https://tailwindcss.com/blog/tailwindcss-v3-4#extended-opacity-scale)
7. Support [Extended grid-rows-* scale](https://tailwindcss.com/blog/tailwindcss-v3-4#extended-grid-rows-scale)
8. Support [New forced-colors variant](https://tailwindcss.com/blog/tailwindcss-v3-4#new-forced-colors-variant)
9. Support [New forced-color-adjust utilities](https://tailwindcss.com/blog/tailwindcss-v3-4#new-forced-color-adjust-utilities)

### 2. 🚨  Deprecate `ShortTailwindest` type

Tailwindest is a project that aims to improve the **readability** and **maintainability** of `taiwlindcss`. However, I've found that writing styling using the `ShortTailwindest` type does not overcome the problems with `tailwindcss`, and actually makes it less readable. Therefore, **`ShortTailwindest` is deprecated**.


## Type of Change

-   [ ] Bug Fix
-   [x] Enhancement
-   [ ] Breaking API Changes
-   [x] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
