### PR TITLE
🐛 add missing word break properties (fixes #103)

### DIFF
--- a/packages/tailwindest/src/types/tailwind/properties/font/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/font/index.ts
@@ -25,6 +25,7 @@ import { TailwindTextUnderlineOffsetType } from "./@text.underline.offset"
 import { TailwindTextWrapType } from "./@text.wrap"
 import { TailwindVerticalAlignType } from "./@vertical.align"
 import { TailwindWhitespaceType } from "./@whitespace"
+import { TailwindWordBreakType } from "./@word.break"
 
 export interface TailwindFontPlug {
     content?: string
@@ -94,4 +95,5 @@ export interface TailwindFont<
         TailwindHyphensType<FontPlug["hyphens"]>,
         TailwindListStylePositionType,
         TailwindVerticalAlignType,
-        TailwindWhitespaceType {}
+        TailwindWhitespaceType,
+        TailwindWordBreakType {}


### PR DESCRIPTION
Adds missing import and extend of TailwindWordBreakType

## Description

Fixes issue #103.

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x]  Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass (note 1)

note 1:
Fails the same tests that a clean pull of trunk does.
```
Bench total result

📦 OS: Linux, @6.8.10-300.fc40.x86_64
📦 MACHINE: AMD Ryzen 7 7840U w/ Radeon  780M Graphics

Bench - style class 10,000,000 iteration:  7.279ms 
Bench - style style 10,000,000 iteration:  36.738ms 
Bench - toggle style [true] 10,000,000 iteration:  126.774ms 
Bench - toggle class [true] 10,000,000 iteration:  122.076ms 
Bench - toggle style [false] 10,000,000 iteration:  155.473ms 
Bench - toggle class [false] 10,000,000 iteration:  151.584ms 
Bench - rotary style [warn] 10,000,000 iteration:  146.833ms 
Bench - rotary class [warn] 10,000,000 iteration:  146.674ms 
Bench - rotary style [pending] 10,000,000 iteration:  148.146ms 
Bench - rotary class [pending] 10,000,000 iteration:  150.152ms 
Bench - variants 10,000,000 iteration:  1,024.117ms 
Bench - merge props 100,000 iteration:  1,549.933ms 
Bench - ⛔ live compose rotary [warn] & [pending] into wind 100,000 iteration:  2,718.999ms 
Bench - ⛔ live compose rotary [pending] & [warn] into wind 100,000 iteration:  2,703.066ms 
```