### PR TITLE
🐛 fix: update wrong name for font-style class

### DIFF
--- a/packages/tailwindest/src/types/tailwind/properties/font/@font.style.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/font/@font.style.ts
@@ -1,4 +1,4 @@
-type TailwindFontStyle = "italic" | "non-italic"
+type TailwindFontStyle = "italic" | "not-italic"
 export type TailwindFontStyleType = {
     /**
      *@description Utilities for controlling the style of text.


### PR DESCRIPTION
## Description

As described here, the correct class name to reset font-style to normal is `not-italic`. The current class name specified is `non-italic`.

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
