### PR TITLE
🐛 Corrected TextIndent variants typing

### DIFF
--- a/packages/tailwindest/src/types/tailwind/properties/font/index.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/font/index.ts
@@ -1,3 +1,4 @@
+import { TailwindSpacingVariants } from "../common"
 import { TailwindContentType } from "./@content"
 import { TailwindFontFamilyType } from "./@font.family"
 import { TailwindFontSizeType } from "./@font.size"
@@ -77,7 +78,7 @@ export interface TailwindFont<
         TailwindFontWeightType<FontPlug["fontSize"]>,
         TailwindFontFamilyType<FontPlug["fontFamily"]>,
         TailwindTextColorType<TailwindColor, FontPlug["textColor"]>,
-        TailwindTextIndentType<TailwindColor, FontPlug["textIndent"]>,
+        TailwindTextIndentType<TailwindSpacingVariants, FontPlug["textIndent"]>,
         TailwindFontSizeType<FontPlug["fontSize"], FontPlug["lineHeight"]>,
         TailwindTextDecorationColorType<
             TailwindColor,


### PR DESCRIPTION
## Description

Text indent typing mistakenly has colours as its variants. Swapped out for sizing

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Functionality is documented
-   [x] Existing issues have been referenced (where applicable)
-   [x] All code style checks pass
-   [x] All new and existing tests pass
