### PR TITLE
[fix] aspect ratio supports `arbitrary values`

### DIFF
--- a/packages/tailwindest/CHANGELOG.md
+++ b/packages/tailwindest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tailwindest
 
+## 2.3.6
+
+### Patch Changes
+
+-   Fix aspect ratio arbitrary values support `aspect-[x/y]`
+
 ## 2.3.5
 
 ### Patch Changes

--- a/packages/tailwindest/package.json
+++ b/packages/tailwindest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tailwindest",
-    "version": "2.3.5",
+    "version": "2.3.6",
     "description": "typesafe, reusable tailwind",
     "homepage": "https://tailwindest.vercel.app",
     "author": "danpacho",

--- a/packages/tailwindest/src/types/tailwind/properties/layout/@aspect.ratio.ts
+++ b/packages/tailwindest/src/types/tailwind/properties/layout/@aspect.ratio.ts
@@ -1,12 +1,15 @@
 import { PlugBase, Pluggable } from "../../../plugin"
 import { TailwindArbitrary } from "../common/@arbitrary"
 
-type TailwindAspectRatio<Plug extends PlugBase = ""> =
-    | "aspect-auto"
-    | "aspect-square"
-    | "aspect-video"
+type TailwindAspectRatioVariants<Plug extends PlugBase = ""> =
+    | "auto"
+    | "square"
+    | "video"
     | Pluggable<Plug>
     | TailwindArbitrary
+
+type TailwindAspectRatio<Plug extends PlugBase = ""> =
+    `aspect-${TailwindAspectRatioVariants<Plug>}`
 
 export type TailwindAspectRatioType<Plug extends PlugBase = ""> = {
     /**


### PR DESCRIPTION
## Description

Now, arbitrary aspect-ratio is possible.

You can use `aspect-[x/y]` kinda syntax.

Huge thanks to issue reporter, @jbs-marcus :)

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
