### PR TITLE
[bug] Remove native prefix for custom tailwind plugins

### DIFF
--- a/packages/create-tailwind-type/CHANGELOG.md
+++ b/packages/create-tailwind-type/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-tailwind-type
 
+## 1.0.6
+
+### Patch Changes
+
+- Remove native prefix combination for custom plugin support
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/create-tailwind-type/package.json
+++ b/packages/create-tailwind-type/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-tailwind-type",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Type generator for tailwindcss",
     "type": "module",
     "sideEffects": false,

--- a/packages/create-tailwind-type/src/generator/generator.ts
+++ b/packages/create-tailwind-type/src/generator/generator.ts
@@ -521,8 +521,7 @@ export class TailwindTypeGenerator {
     }
 
     private getPropertyNameTailwindKeyNotFounded(
-        className: string,
-        useNativeCombine: boolean
+        className: string
     ): string | null {
         const findTrierClassNames = [
             // purified -> original
@@ -572,12 +571,12 @@ export class TailwindTypeGenerator {
             )
 
             if (uniqueProperty) {
-                if (matchedVariantName && useNativeCombine) {
-                    const withTwNative = `${matchedVariantName}${capitalize(
-                        uniqueProperty
-                    )}`
-                    return withTwNative
-                }
+                // if (matchedVariantName && useNativeCombine) {
+                //     const withTwNative = `${matchedVariantName}${capitalize(
+                //         uniqueProperty
+                //     )}`
+                //     return withTwNative
+                // }
                 return uniqueProperty
             }
 
@@ -685,10 +684,8 @@ export class TailwindTypeGenerator {
             this.generateKey(className, uniqueKeySet)
 
         if (tailwindKey === null) {
-            const property = this.getPropertyNameTailwindKeyNotFounded(
-                className,
-                false
-            )
+            const property =
+                this.getPropertyNameTailwindKeyNotFounded(className)
 
             return property
         }
@@ -772,7 +769,7 @@ export class TailwindTypeGenerator {
             exactNames.length === 0 && similarNames.length === 0
 
         if (propertyNameNotFounded) {
-            return this.getPropertyNameTailwindKeyNotFounded(className, true)
+            return this.getPropertyNameTailwindKeyNotFounded(className)
         }
 
         if (exactNames.length >= 1) {


### PR DESCRIPTION
## Description

For custom tailwind plugins, it generates weird property names. So remove `useNativeCombine` logic for generating property names.

close #139 

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
