### PR TITLE
[bug] deepmerge nullable object transformation issue

### DIFF
--- a/packages/tailwindest/src/tools/__tests__/create_tools.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/create_tools.test.ts
@@ -3,6 +3,7 @@ import { PrimitiveStyler } from "../primitive"
 import { RotaryStyler } from "../rotary"
 import { VariantsStyler } from "../variants"
 import { createTools } from "../create_tools"
+import { ToggleStyler } from "../toggle"
 
 describe("PrimitiveStyler", () => {
     type TestStyle = { color: string; fontSize?: string }
@@ -159,6 +160,91 @@ describe("RotaryStyler", () => {
             })
             expect(newStyler.style("primary")).toEqual({
                 color: "blue",
+                fontSize: "12",
+            })
+        })
+    })
+})
+
+describe("ToggleStyler", () => {
+    type TestStyle = { color: string; fontSize?: string }
+    type VariantKey = "truthy" | "falsy" | "base"
+    describe("constructor", () => {
+        it("initializes with variants and base", () => {
+            const toggle: Record<VariantKey, TestStyle> = {
+                base: { color: "base" },
+                truthy: { color: "blue" },
+                falsy: { color: "green" },
+            }
+            const styler = new ToggleStyler<TestStyle>(toggle)
+            expect(styler).toBeInstanceOf(ToggleStyler)
+        })
+    })
+
+    describe("class method", () => {
+        it("returns class name for variant", () => {
+            const toggle: Record<VariantKey, TestStyle> = {
+                base: { color: "base" },
+                truthy: { color: "blue" },
+                falsy: { color: "green" },
+            }
+            const styler = new ToggleStyler<TestStyle>(toggle)
+            expect(styler.class(true)).toBe("blue")
+        })
+
+        it("concatenates with extra class name", () => {
+            const toggle: Record<VariantKey, TestStyle> = {
+                base: { color: "base" },
+                truthy: { color: "blue" },
+                falsy: { color: "green" },
+            }
+            const styler = new ToggleStyler<TestStyle>(toggle)
+            expect(styler.class(true, "extra")).toBe("blue extra")
+        })
+    })
+
+    describe("style method", () => {
+        it("returns style for true", () => {
+            const toggle: Record<VariantKey, TestStyle> = {
+                base: { color: "base" },
+                truthy: { color: "blue" },
+                falsy: { color: "green" },
+            }
+            const styler = new ToggleStyler<TestStyle>(toggle)
+            expect(styler.style(true)).toEqual({ color: "blue" })
+        })
+
+        it("merges with extra style", () => {
+            const toggle: Record<VariantKey, TestStyle> = {
+                base: { color: "base" },
+                truthy: { color: "blue" },
+                falsy: { color: "green" },
+            }
+            const styler = new ToggleStyler<TestStyle>(toggle)
+            expect(
+                styler.style(true, { fontSize: "16", color: "green" })
+            ).toEqual({
+                color: "green",
+                fontSize: "16",
+            })
+        })
+    })
+
+    describe("compose method", () => {
+        it("creates new styler with composed base", () => {
+            const toggle: Record<VariantKey, TestStyle> = {
+                base: { color: "base" },
+                truthy: { color: "blue" },
+                falsy: { color: "green" },
+            }
+            const styler = new ToggleStyler<TestStyle>(toggle)
+            const newStyler = styler.compose({ fontSize: "12", color: "gray" })
+            expect(newStyler.style(true)).toEqual({
+                color: "blue",
+                fontSize: "12",
+            })
+            expect(newStyler.style(false)).toEqual({
+                color: "green",
                 fontSize: "12",
             })
         })
@@ -398,17 +484,16 @@ describe("createTools", () => {
 
         it("should join style values", () => {
             const tools = createTools<{}>()
-            expect(
-                tools.join(
-                    "bg-red-100",
-                    "p-2",
-                    "m-2",
-                    { cls: true },
-                    { cls2: false },
-                    { cls3: true },
-                    ["arr1", "arr2", { cls4: true }]
-                )
-            ).toBe("bg-red-100 p-2 m-2 cls cls3 arr1 arr2 cls4")
+            const join1 = tools.join(
+                "bg-red-100",
+                "p-2",
+                "m-2",
+                { cls: true },
+                { cls2: false },
+                { cls3: true },
+                ["arr1", "arr2", { cls4: true }]
+            )
+            expect(join1).toBe("bg-red-100 p-2 m-2 cls cls3 arr1 arr2 cls4")
         })
     })
 })

--- a/packages/tailwindest/src/tools/__tests__/styler.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/styler.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { Styler } from "../styler" // Adjust path as needed
+import type { Merger } from "../merger_interface"
+
+// Mock implementation of Styler for testing abstract methods
+class TestStyler extends Styler<string, Record<string, unknown>> {
+    public class(key: string, extraClassName?: string): string {
+        return this.merger(key, extraClassName || "")
+    }
+
+    public style(key: string, extraStyle?: Record<string, unknown>): unknown {
+        return { [key]: extraStyle || "test" }
+    }
+
+    public compose(...styles: Array<Record<string, unknown>>): unknown {
+        return Styler.deepMerge(...styles)
+    }
+}
+
+describe("Styler", () => {
+    describe("merger", () => {
+        it("uses default merger when none set", () => {
+            const styler = new TestStyler()
+            expect(styler.merger("a", "b")).toBe("a b")
+        })
+
+        it("uses custom merger when set", () => {
+            const styler = new TestStyler()
+            const customMerger: Merger = vi.fn((...classes) =>
+                classes.join("-")
+            )
+            styler.setMerger(customMerger)
+            expect(styler.merger("a", "b")).toBe("a-b")
+            expect(customMerger).toHaveBeenCalledWith("a", "b")
+        })
+    })
+
+    describe("flattenRecord", () => {
+        it("flattens nested record to string array", () => {
+            const input = {
+                a: "class1",
+                b: {
+                    c: "class2",
+                    d: {
+                        e: "class3",
+                    },
+                },
+            }
+            const result = Styler.flattenRecord(input)
+            expect(result).toEqual(["class1", "class2", "class3"])
+        })
+
+        it("handles empty object", () => {
+            expect(Styler.flattenRecord({})).toEqual([])
+        })
+
+        it("handles undefined", () => {
+            expect(Styler.flattenRecord(undefined)).toEqual([])
+        })
+    })
+
+    describe("deepMerge", () => {
+        it("merges simple objects", () => {
+            const result = Styler.deepMerge({ a: "1" }, { b: "2" })
+            expect(result).toEqual({ a: "1", b: "2" })
+        })
+
+        it("merges nested objects", () => {
+            const result = Styler.deepMerge(
+                { a: { b: "1" } },
+                { a: { c: "2" } }
+            )
+            expect(result).toEqual({ a: { b: "1", c: "2" } })
+        })
+
+        it("concatenates arrays", () => {
+            const result = Styler.deepMerge({ a: ["1"] }, { a: ["2"] })
+            expect(result).toEqual({ a: ["1", "2"] })
+        })
+
+        it("handles mixed array and non-array", () => {
+            const result = Styler.deepMerge({ a: "1" }, { a: ["2"] })
+            expect(result).toEqual({ a: ["1", "2"] })
+        })
+
+        it("overrides non-object values", () => {
+            const result = Styler.deepMerge({ a: "1" }, { a: "2" })
+            expect(result).toEqual({ a: "2" })
+        })
+    })
+
+    describe("getClassName", () => {
+        it("converts style object to className string", () => {
+            const style = {
+                a: "class1",
+                b: {
+                    c: "class2",
+                },
+            }
+            expect(Styler.getClassName(style)).toBe("class1 class2")
+        })
+
+        it("handles empty style", () => {
+            expect(Styler.getClassName({})).toBe("")
+        })
+    })
+
+    describe("TestStyler implementation", () => {
+        let styler: TestStyler
+
+        beforeEach(() => {
+            styler = new TestStyler()
+        })
+
+        it("class method uses merger", () => {
+            expect(styler.class("test", "extra")).toBe("test extra")
+        })
+
+        it("style method returns object", () => {
+            expect(styler.style("key", { extra: "value" })).toEqual({
+                key: { extra: "value" },
+            })
+        })
+
+        it("compose method merges styles", () => {
+            const result = styler.compose({ a: "1" }, { b: "2" })
+            expect(result).toEqual({ a: "1", b: "2" })
+        })
+    })
+})

--- a/packages/tailwindest/src/tools/create_tools.ts
+++ b/packages/tailwindest/src/tools/create_tools.ts
@@ -4,7 +4,7 @@ import { RotaryStyler } from "./rotary"
 import { type VariantsRecord, VariantsStyler } from "./variants"
 import { Styler } from "./styler"
 import type { Merger } from "./merger_interface"
-import { type ClassList, toClass } from "./to_class"
+import { toClass, type ClassList } from "./to_class"
 
 type Stringify<T> = T extends string ? T : never
 
@@ -24,6 +24,14 @@ interface ToolOptions {
 }
 
 export const createTools = <StyleType>({ merger }: ToolOptions = {}) => {
+    const join = (...classList: ClassList): string => {
+        const res = toClass(classList)
+        if (merger) {
+            return merger(res)
+        }
+        return res
+    }
+
     const style = (stylesheet: StyleType) => {
         const styler = new PrimitiveStyler<StyleType>(stylesheet)
         if (merger) {
@@ -32,19 +40,6 @@ export const createTools = <StyleType>({ merger }: ToolOptions = {}) => {
         return styler
     }
 
-    /**
-     * Create `toggle` styler
-     * @example
-     * ```tsx
-     * const themeBtn = tw.toggle({
-     *      base  : {},   // [optional] base style
-     *      truthy: {},   // light mode
-     *      falsy : {},   // dark mode
-     * })
-     *
-     * const light = themeBtn.class(true)
-     * ```
-     */
     const toggle = (toggleVariants: ToggleVariants<StyleType>) => {
         const styler = new ToggleStyler<StyleType>(toggleVariants)
         if (merger) {
@@ -53,22 +48,6 @@ export const createTools = <StyleType>({ merger }: ToolOptions = {}) => {
         return styler
     }
 
-    /**
-     * Create `rotary` styler
-     * @example
-     * ```tsx
-     * const btn = tw.rotary({
-     *      variants: {
-     *          default: {},
-     *          success: {},
-     *          warning: {},
-     *      },
-     *      base: {},   // [optional] base style
-     * })
-     *
-     * const warningBtn = btn.class("warning")
-     * ```
-     */
     const rotary = <VRecord extends Record<string, StyleType>>(params: {
         base?: StyleType
         variants: VRecord
@@ -82,29 +61,6 @@ export const createTools = <StyleType>({ merger }: ToolOptions = {}) => {
         return styler
     }
 
-    /**
-     * Create `variants` styler
-     * @example
-     * ```tsx
-     * const btn = tw.variants({
-     *      variants: {
-     *          type: {
-     *              default: {},
-     *              success: {},
-     *              warning: {},
-     *          },
-     *          size: {
-     *              sm: {},
-     *              md: {},
-     *              lg: {},
-     *          },
-     *      },
-     *      base: {},   // [optional] base style
-     * })
-     *
-     * btn.class({ size: "md", type: "default" })
-     * ```
-     */
     const variants = <VMap extends VariantsRecord<StyleType>>(params: {
         base?: StyleType
         variants: VMap
@@ -116,53 +72,11 @@ export const createTools = <StyleType>({ merger }: ToolOptions = {}) => {
         return styler
     }
 
-    /**
-     * Merge two record
-     * @returns Merged record
-     * @example
-     * ```tsx
-     * tw.mergeRecord(
-     *      {
-     *          color: "text-gray-950",
-     *          fontWeight: "font-bold",
-     *          fontSize: "text-base",
-     *      },
-     *      {
-     *          color: "text-red-100",
-     *      }
-     * }
-     *
-     * //   {
-     * //       color: "text-red-100",
-     * //       fontWeight: "font-bold",
-     * //       fontSize: "text-base",
-     * //   }
-     * ```
-     */
     const mergeRecord = (
         baseRecord: StyleType,
         overrideRecord: StyleType
     ): StyleType => Styler.deepMerge(baseRecord, overrideRecord)
 
-    /**
-     * Merge two style record into string
-     * @returns Merged className `string`
-     * @example
-     * ```tsx
-     * tw.mergeProps(
-     *      {
-     *          color: "text-gray-950",
-     *          fontWeight: "font-bold",
-     *          fontSize: "text-base",
-     *      },
-     *      {
-     *          color: "text-red-100",
-     *      }
-     * }
-     *
-     * // text-red-100 font-bold text-base
-     * ```
-     */
     const mergeProps = (baseStyle: StyleType, styleProps: StyleType) => {
         const res = Styler.getClassName(mergeRecord(baseStyle, styleProps))
         if (merger) {
@@ -171,26 +85,128 @@ export const createTools = <StyleType>({ merger }: ToolOptions = {}) => {
         return res
     }
 
-    /**
-     * Join all the possible combinations into string
-     * @param classList all the possible sheet format
-     * @see {@link https://github.com/lukeed/clsx#readme clsx}
-     */
-    const join = (...classList: ClassList): string => {
-        const res = toClass(classList)
-        if (merger) {
-            return merger(res)
-        }
-        return res
-    }
-
     return {
+        /**
+         * Join all the possible combinations into string
+         * @param classList all the possible sheet format
+         * @see {@link https://github.com/lukeed/clsx#readme clsx}
+         */
         join,
+        /**
+         * Create `rotary` styler
+         * @example
+         * ```tsx
+         * const btn = tw.rotary({
+         *      variants: {
+         *          default: {},
+         *          success: {},
+         *          warning: {},
+         *      },
+         *      base: {},   // [optional] base style
+         * })
+         *
+         * const warningBtn = btn.class("warning")
+         * ```
+         */
         style,
+        /**
+         * Create `toggle` styler
+         * @example
+         * ```tsx
+         * const themeBtn = tw.toggle({
+         *      base  : {},   // [optional] base style
+         *      truthy: {},   // light mode
+         *      falsy : {},   // dark mode
+         * })
+         *
+         * const light = themeBtn.class(true)
+         * ```
+         */
         toggle,
+        /**
+         * Create `rotary` styler
+         * @example
+         * ```tsx
+         * const box = tw.rotary({
+         *      variants: {
+         *          sm: {},
+         *          md: {},
+         *          lg: {},
+         *      },
+         *      base: {},   // [optional] base style
+         * })
+         *
+         * const mdBox = themeBtn.class("md")
+         * ```
+         */
         rotary,
+        /**
+         * Create `variants` styler
+         * @example
+         * ```tsx
+         * const btn = tw.variants({
+         *      variants: {
+         *          type: {
+         *              default: {},
+         *              success: {},
+         *              warning: {},
+         *          },
+         *          size: {
+         *              sm: {},
+         *              md: {},
+         *              lg: {},
+         *          },
+         *      },
+         *      base: {},   // [optional] base style
+         * })
+         *
+         * btn.class({ size: "md", type: "default" })
+         * ```
+         */
         variants,
+        /**
+         * Merge two style record into string
+         * @returns Merged className `string`
+         * @example
+         * ```tsx
+         * tw.mergeProps(
+         *      {
+         *          color: "text-gray-950",
+         *          fontWeight: "font-bold",
+         *          fontSize: "text-base",
+         *      },
+         *      {
+         *          color: "text-red-100",
+         *      }
+         * }
+         *
+         * // text-red-100 font-bold text-base
+         * ```
+         */
         mergeProps,
+        /**
+         * Merge two record
+         * @returns Merged record
+         * @example
+         * ```tsx
+         * tw.mergeRecord(
+         *      {
+         *          color: "text-gray-950",
+         *          fontWeight: "font-bold",
+         *          fontSize: "text-base",
+         *      },
+         *      {
+         *          color: "text-red-100",
+         *      }
+         * }
+         *
+         * //   {
+         * //       color: "text-red-100",
+         * //       fontWeight: "font-bold",
+         * //       fontSize: "text-base",
+         * //   }
+         * ```
+         */
         mergeRecord,
     }
 }

--- a/packages/tailwindest/src/tools/styler.ts
+++ b/packages/tailwindest/src/tools/styler.ts
@@ -58,6 +58,8 @@ export abstract class Styler<Args, Out> {
     ): MergeTargetObject {
         return nestedRecordList.reduce<NestedRecord>(
             (mergedObject, currentObject) => {
+                if (!currentObject) return mergedObject
+
                 for (const [key, value] of Object.entries(
                     currentObject as NestedRecord
                 )) {

--- a/packages/tailwindest/src/tools/toggle.ts
+++ b/packages/tailwindest/src/tools/toggle.ts
@@ -45,10 +45,10 @@ export class ToggleStyler<StyleType> extends Styler<boolean, StyleType> {
      * @param condition toggle condition
      * @param extraStyle extra stylesheet
      */
-    public style(condition: boolean, extraStyle?: StyleType) {
+    public style(condition: boolean, extraStyle?: StyleType): StyleType {
         const inquired = this._rotary.style(condition ? "T" : "F")
         if (!extraStyle) inquired
-        return Styler.deepMerge(inquired, extraStyle)
+        return Styler.deepMerge(inquired, extraStyle)!
     }
 
     public compose(...styles: Array<StyleType>): ToggleStyler<StyleType> {

--- a/packages/tailwindest/src/tools/variants.ts
+++ b/packages/tailwindest/src/tools/variants.ts
@@ -57,7 +57,8 @@ export class VariantsStyler<
 
         for (const [variantKey, subVariant] of Object.entries(variant)) {
             if (subVariant) {
-                const subStyler = this._variantStylerMap[variantKey]!
+                const subStyler = this._variantStylerMap?.[variantKey]
+                if (!subStyler) continue
                 const subStyle = subStyler.style(subVariant)
                 merged = Styler.deepMerge(merged, subStyle)
             }


### PR DESCRIPTION
## Description

- Fix `deepMerge` related nullable issues
- Fix undefinable return value at toggle `style` method
- Fix nullable key-value pair at `variants` method, and enhance null-safety
- Update `createTools` docs for exported modules

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [x] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
