### PR TITLE
[bug] `twMerge` does not match `createtools` - `merger` typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/danpacho/tailwindest"
     },
     "type": "module",
-    "packageManager": "pnpm@10.4.1",
+    "packageManager": "pnpm@10.6.5",
     "scripts": {
         "dev": "turbo run dev",
         "build": "turbo run build",
@@ -31,7 +31,7 @@
         "eslint": "eslint packages/**/**/*.ts",
         "eslint:fix": "eslint packages/**/**/*.ts --fix",
         "pkg:init": "pnpm test:ci && changeset",
-        "pkg:version": "changeset version",
+        "pkg:version": "pnpm build && changeset version",
         "pkg:publish": "changeset publish",
         "pre-commit": "lint-staged",
         "prepare": "husky install"

--- a/packages/create-tailwind-type/src/site_extractor/docs/lcp_class.test.js
+++ b/packages/create-tailwind-type/src/site_extractor/docs/lcp_class.test.js
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest"
-import { getTailwindLCP } from "./lcp_class"
+import { getTailwindLCP } from "./lcp_class.mjs"
 import { expect } from "vitest"
 describe("LCP for tw classes", () => {
     it("Should extract LCP for tailwindcss", () => {

--- a/packages/create-tailwind-type/src/site_extractor/jsconfig.json
+++ b/packages/create-tailwind-type/src/site_extractor/jsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "ESNext",
-        "module": "ESNext",
+        "module": "NodeNext",
         "strict": true,
         "allowJs": true,
         "checkJs": true,

--- a/packages/tailwindest/CHANGELOG.md
+++ b/packages/tailwindest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tailwindest
 
+## 3.1.1
+
+### Patch Changes
+
+- Fix merge interface type compatibility issue, update join/def function merging process
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/tailwindest/package.json
+++ b/packages/tailwindest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tailwindest",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "typesafe, reusable tailwind",
     "homepage": "https://tailwindest.vercel.app",
     "author": "danpacho",

--- a/packages/tailwindest/package.json
+++ b/packages/tailwindest/package.json
@@ -27,5 +27,8 @@
     },
     "dependencies": {
         "clsx": "^2.1.1"
+    },
+    "devDependencies": {
+        "tailwind-merge": "latest"
     }
 }

--- a/packages/tailwindest/src/index.ts
+++ b/packages/tailwindest/src/index.ts
@@ -1,6 +1,10 @@
 import { createTools, type GetVariants } from "./tools"
 import { CreateTailwindest } from "./create_tailwindest"
 
+// Merger public interfaces
+export type { Merger as TailwindestMerger } from "./tools/merger_interface"
+export type { ClassList as TailwindestClassList } from "./tools/to_class"
+
 // V2 + tailwindcss < 4.0
 export type { Tailwindest } from "./legacy/tailwindest"
 export type { ShortTailwindest } from "./legacy/tailwindest.short"

--- a/packages/tailwindest/src/tools/__tests__/merger_interface.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/merger_interface.test.ts
@@ -1,0 +1,70 @@
+import { expectType, TypeEqual } from "ts-expect"
+import { describe, expect, it } from "vitest"
+import { twMerge } from "tailwind-merge"
+import { Merger } from "../merger_interface"
+import { createTools } from "../create_tools"
+import { CreateTailwindest } from "../../create_tailwindest"
+import { ClassList } from "../to_class"
+
+describe("Merger interface", () => {
+    it("1. tailwind-merge", () => {
+        const merger: Merger = twMerge
+        const t = createTools<
+            CreateTailwindest<{
+                tailwind: Record<string, any>
+                tailwindNestGroups: ""
+                useArbitrary: true
+            }>
+        >({
+            merger: merger,
+        })
+
+        const deduplicatedByTwMerge = t.def(["bg-red-100", "bg-red-200", "p-2"])
+        expect(deduplicatedByTwMerge).toBe("bg-red-200 p-2")
+
+        const argumentOrderHasPriority = t.def(
+            ["bg-red-100", "bg-red-200", "p-2"],
+            {
+                backgroundColor: "bg-red-300",
+            }
+        )
+        expect(argumentOrderHasPriority).toBe("p-2 bg-red-300")
+    })
+    it("2. custom-merger", () => {
+        const customMerger: Merger<ClassList> = (...args) => {
+            const res = args
+                .map((e) => {
+                    if (typeof e === "string") {
+                        return e
+                    }
+                    if (Array.isArray(e)) {
+                        return customMerger(...e)
+                    }
+                    throw new Error("Invalid merging value")
+                })
+                .filter(Boolean)
+                .join(" with ")
+            return res
+        }
+
+        const t = createTools<
+            CreateTailwindest<{
+                tailwind: Record<string, any>
+                tailwindNestGroups: ""
+                useArbitrary: true
+            }>
+        >({
+            merger: customMerger,
+        })
+
+        const style1 = t.def([["bg-red-100", "bg-red-200"], "p-2"])
+        expect(style1).toBe("bg-red-100 with bg-red-200 with p-2")
+
+        const style2 = t.def(["bg-red-100", "bg-red-200", "p-2"], {
+            backgroundColor: "bg-red-300",
+        })
+        expect(style2).toBe(
+            "bg-red-100 with bg-red-200 with p-2 with bg-red-300"
+        )
+    })
+})

--- a/packages/tailwindest/src/tools/create_tools.ts
+++ b/packages/tailwindest/src/tools/create_tools.ts
@@ -166,19 +166,20 @@ export const createTools = <Type extends TailwindestInterface>({
          */
         join,
         /**
-         * Create `rotary` styler
+         * Create primitive style
          * @example
          * ```tsx
-         * const btn = tw.rotary({
-         *      variants: {
-         *          default: {},
-         *          success: {},
-         *          warning: {},
+         * const box = tw.style({
+         *      display: "flex",
+         *      alignItems: "items-center",
+         *      padding: ["px-2", "py-[2.25px]"],
+         *      hover: {
+         *          opacity: "hover:opacity-90"
          *      },
-         *      base: {},   // [optional] base style
+         *      sm: {
+         *          padding: ["px-1", "py-[1.25px]"],
+         *      }
          * })
-         *
-         * const warningBtn = btn.class("warning")
          * ```
          */
         style,

--- a/packages/tailwindest/src/tools/create_tools.ts
+++ b/packages/tailwindest/src/tools/create_tools.ts
@@ -62,13 +62,8 @@ export const createTools = <Type extends TailwindestInterface>({
         : TailwindLiteral
     type StyleType = Type["tailwindest"]
 
-    const join = (...classList: ClassList<ClassLiteral>): string => {
-        const res = toClass(classList)
-        if (merger) {
-            return merger(res)
-        }
-        return res
-    }
+    const join = (...classList: ClassList<ClassLiteral>): string =>
+        merger ? toClass(merger(...classList)) : toClass(classList)
 
     const style = (stylesheet: StyleType): PrimitiveStyler<StyleType> => {
         const styler = new PrimitiveStyler<StyleType>(stylesheet)
@@ -129,13 +124,7 @@ export const createTools = <Type extends TailwindestInterface>({
     const def = (
         classList: ClassList<ClassLiteral>,
         ...styleList: Array<StyleType>
-    ): string => {
-        const res = toDef(classList, styleList, mergeProps, join)
-        if (merger) {
-            return merger(res)
-        }
-        return res
-    }
+    ): string => toDef<StyleType>(classList, styleList, mergeProps, join)
 
     return {
         /**
@@ -163,6 +152,10 @@ export const createTools = <Type extends TailwindestInterface>({
          * Join all the possible combinations into string
          * @param classList all the possible sheet format
          * @see {@link https://github.com/lukeed/clsx#readme clsx}
+         * @example
+         * ```ts
+         * const box = tw.join(...values)
+         * ```
          */
         join,
         /**

--- a/packages/tailwindest/src/tools/merger_interface.ts
+++ b/packages/tailwindest/src/tools/merger_interface.ts
@@ -1,6 +1,7 @@
-import type { ClassList } from "./to_class"
-
 /**
- * Merge class list into one valid style classname string
+ * @interface
+ * Merge arbitrary class list into one valid style classname string
  */
-export type Merger = (...classList: ClassList) => string
+export type Merger<ClassList extends Array<any> = any[]> = (
+    ...classList: ClassList
+) => string

--- a/packages/tailwindest/src/tools/to_class.ts
+++ b/packages/tailwindest/src/tools/to_class.ts
@@ -11,6 +11,11 @@ type ClassValue<Literal extends string = string> =
     | boolean
     | undefined
 type ClassDictionary = Record<string, any>
+
+/**
+ * @interface
+ * Default supported class list
+ */
 export type ClassList<Literal extends string = string> = ClassValue<Literal>[]
 
 export function toClass<Literal extends string = string>(

--- a/packages/tailwindest/src/tools/to_def.ts
+++ b/packages/tailwindest/src/tools/to_def.ts
@@ -1,12 +1,12 @@
 import type { ClassList } from "./to_class"
 
-export function toDef<StyleType, Literal extends string = string>(
-    classList: ClassList<Literal>,
+export function toDef<StyleType>(
+    classList: ClassList<string>,
     styleList: Array<StyleType>,
     styleMerger: (...styles: Array<StyleType>) => string,
-    join: (...classList: ClassList<Literal>) => string
+    join: (...classList: ClassList<string>) => string
 ): string {
     const classLiteral = join(...classList)
     const styleLiteral = styleMerger(...styleList)
-    return join([classLiteral, styleLiteral])
+    return join(classLiteral, styleLiteral)
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,10 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+    devDependencies:
+      tailwind-merge:
+        specifier: latest
+        version: 3.0.2
 
   site:
     dependencies:
@@ -3943,6 +3947,9 @@ packages:
   synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tailwind-merge@3.0.2:
+    resolution: {integrity: sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==}
 
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
@@ -8902,6 +8909,8 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.1.1
       tslib: 2.8.1
+
+  tailwind-merge@3.0.2: {}
 
   tailwindcss@3.4.17:
     dependencies:


### PR DESCRIPTION
## Description

- Change public merger interface for more generic approach.
     ```ts
     export type Merger<ClassList extends Array<any> = any[]> = (
         ...classList: ClassList
     ) => string
     ```
- Change internal `join`, `def` logic. Remove duplicated merging process, fix invalid argument spreading.
- Export public interface types for merging
    - `TailwindestMerger` : merger function shape
    - `TailwindestClassList` : default tailwindest's native merging target valid class lists.
- Can inject custom merger, based on `TailwindestMerger` and `TailwindestClassList`.
     ```ts
     const merger_1: TailwindestMerger<TailwindestClassList> = (...values) => { ... }
     const merger_2: TailwindestMerger<Array<string> | string> = (...values) => { ... }
     ...
     ```

closes #150 

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [x] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
