### PR TITLE
[bug] ts7056 ts4094 error when building dts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,28 @@ npm i tailwindest@latest
 ### 3. Create tools
 
 ```ts
-import { createTools, type CreateTailwindest } from "tailwindest"
+import {
+    createTools,
+    type CreateTailwindest,
+    type CreateTailwindLiteral,
+} from "tailwindest"
+
 import type { Tailwind, TailwindNestGroups } from "./tailwind"
 import { twMerge } from "tailwind-merge"
 
-type Tailwindest = CreateTailwindest<{
+export type Tailwindest = CreateTailwindest<{
     tailwind: Tailwind
     tailwindNestGroups: TailwindNestGroups
     groupPrefix: "$" // prefix for nest groups, [optional]
-    useArbitrary: true // use arbitrary values, [optional]
+    useArbitrary: true // enable arbitrary values, [optional]
 }>
+export type TailwindLiteral = CreateTailwindLiteral<Tailwind>
 
-export const tw = createTools<Tailwindest>({
+export const tw = createTools<{
+    tailwindest: Tailwindest
+    tailwindLiteral: TailwindLiteral
+    useArbitrary: true // enable arbitrary values, [optional]
+}>({
     merger: twMerge, // set tailwind-merge as merger, [optional]
 })
 ```

--- a/packages/create-tailwind-type/src/generator/__tests__/generator.test.ts
+++ b/packages/create-tailwind-type/src/generator/__tests__/generator.test.ts
@@ -4,41 +4,43 @@ import { TailwindCompiler } from "../../internal/compiler"
 import { CSSAnalyzer } from "../css_analyzer"
 import { TypeSchemaGenerator } from "../../type_tools"
 
-describe("TypeGenerator", () => {
-    // dependencies
-    const compiler = new TailwindCompiler({
-        cssRoot: `${__dirname}/__mocks__/tailwind.css`,
-        base: "packages/create-tailwind-type/node_modules/tailwindcss",
-    })
-    const cssAnalyzer = new CSSAnalyzer()
-    const schemaGenerator = new TypeSchemaGenerator()
+describe(
+    "TypeGenerator",
+    () => {
+        // dependencies
+        const compiler = new TailwindCompiler({
+            cssRoot: `${__dirname}/__mocks__/tailwind.css`,
+            base: "packages/create-tailwind-type/node_modules/tailwindcss",
+        })
+        const cssAnalyzer = new CSSAnalyzer()
+        const schemaGenerator = new TypeSchemaGenerator()
 
-    const generator = new TailwindTypeGenerator({
-        compiler,
-        cssAnalyzer,
-        generator: schemaGenerator,
-        storeRoot: `${__dirname}/__mocks__/store/docs.json`,
-    }).setGenOptions({
-        useDocs: true,
-        useExactVariants: false,
-        useArbitraryValue: false,
-        useSoftVariants: true,
-        useStringKindVariantsOnly: false,
-        useOptionalProperty: false,
-        disableVariants: true,
-    })
+        const generator = new TailwindTypeGenerator({
+            compiler,
+            cssAnalyzer,
+            generator: schemaGenerator,
+            storeRoot: `${__dirname}/__mocks__/store/docs.json`,
+        }).setGenOptions({
+            useDocs: true,
+            useExactVariants: false,
+            useArbitraryValue: false,
+            useSoftVariants: true,
+            useStringKindVariantsOnly: false,
+            useOptionalProperty: false,
+            disableVariants: true,
+        })
 
-    it("should init", async () => {
-        await generator.init()
+        it("should init", async () => {
+            await generator.init()
 
-        expect(generator.ds).toBeDefined()
-        expect(generator.classList.length).toBeGreaterThan(0)
-        expect(generator.variantsEntry.length).toBeGreaterThan(0)
-        expect(generator.variants.length).toBeGreaterThan(0)
-    })
+            expect(generator.ds).toBeDefined()
+            expect(generator.classList.length).toBeGreaterThan(0)
+            expect(generator.variantsEntry.length).toBeGreaterThan(0)
+            expect(generator.variants.length).toBeGreaterThan(0)
+        })
 
-    it("should extract all the possible variants", () => {
-        expect(generator.variants).toMatchInlineSnapshot(`
+        it("should extract all the possible variants", () => {
+            expect(generator.variants).toMatchInlineSnapshot(`
           [
             "*",
             "**",
@@ -441,11 +443,15 @@ describe("TypeGenerator", () => {
             "noscript",
           ]
         `)
-    })
-
-    it("should build types", async () => {
-        await generator.buildTypes({
-            tailwind: `${__dirname}/__mocks__/dist/tailwind.ts`,
         })
-    })
-})
+
+        it("should build types", async () => {
+            await generator.buildTypes({
+                tailwind: `${__dirname}/__mocks__/dist/tailwind.ts`,
+            })
+        })
+    },
+    {
+        timeout: 1000 * 20,
+    }
+)

--- a/packages/tailwindest/CHANGELOG.md
+++ b/packages/tailwindest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tailwindest
 
+## 3.2.0
+
+### Minor Changes
+
+- Fix TS7056, TS4094 error for .d.ts building, update tailwindest interface for `createTools` generic param
+
 ## 3.1.1
 
 ### Patch Changes

--- a/packages/tailwindest/package.json
+++ b/packages/tailwindest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tailwindest",
-    "version": "3.1.1",
+    "version": "3.2.0",
     "description": "typesafe, reusable tailwind",
     "homepage": "https://tailwindest.vercel.app",
     "author": "danpacho",

--- a/packages/tailwindest/readme.md
+++ b/packages/tailwindest/readme.md
@@ -17,17 +17,28 @@ npm i tailwindest@latest
 ### 3. Create tools
 
 ```ts
-import { createTools, type CreateTailwindest } from "tailwindest"
+import {
+    createTools,
+    type CreateTailwindest,
+    type CreateTailwindLiteral,
+} from "tailwindest"
+
 import type { Tailwind, TailwindNestGroups } from "./tailwind"
 import { twMerge } from "tailwind-merge"
 
-export const tw = createTools<
-    CreateTailwindest<{
-        tailwind: Tailwind
-        tailwindNestGroups: TailwindNestGroups
-        groupPrefix: "$" // prefix for nest groups, [optional]
-    }>
->({
+export type Tailwindest = CreateTailwindest<{
+    tailwind: Tailwind
+    tailwindNestGroups: TailwindNestGroups
+    groupPrefix: "$" // prefix for nest groups, [optional]
+    useArbitrary: true // enable arbitrary values, [optional]
+}>
+export type TailwindLiteral = CreateTailwindLiteral<Tailwind>
+
+export const tw = createTools<{
+    tailwindest: Tailwindest
+    tailwindLiteral: TailwindLiteral
+    useArbitrary: true // enable arbitrary values, [optional]
+}>({
     merger: twMerge, // set tailwind-merge as merger, [optional]
 })
 ```

--- a/packages/tailwindest/src/create_tailwindest.ts
+++ b/packages/tailwindest/src/create_tailwindest.ts
@@ -77,19 +77,11 @@ interface TailwindestConfig {
 
 export interface TailwindestInterface {
     /**
-     * Tailwind
-     */
-    tailwind?: any
-    /**
-     * Tailwind Literal
+     * Tailwind literal typeset
      */
     tailwindLiteral?: any
     /**
-     * Tailwind Nest Groups
-     */
-    tailwindNestGroup?: any
-    /**
-     * Tailwindest impl
+     * Tailwindest typeset
      */
     tailwindest: any
     /**
@@ -99,7 +91,7 @@ export interface TailwindestInterface {
 }
 
 /**
- * Creates a `tailwindest` typeset.
+ * Create tailwindest typeset
  *
  * @description Run `npx create-tailwind-type` to generate tailwind type defs.
  * ```bash
@@ -121,34 +113,33 @@ export interface TailwindestInterface {
  * }>
  * ```
  */
-export type CreateTailwindest<Config extends TailwindestConfig> = {
-    /**
-     * Tailwind
-     */
-    tailwind: Config["tailwind"]
-    /**
-     * Tailwind Literal
-     */
-    tailwindLiteral: Config["tailwind"][keyof Config["tailwind"]]
-    /**
-     * Tailwind Nest Groups
-     */
-    tailwindNestGroup: Config["tailwindNestGroups"]
-    /**
-     * Tailwindest impl
-     */
-    tailwindest: GetNestStyle<
-        Config["groupPrefix"] extends string
-            ? `${Config["groupPrefix"]}${Config["tailwindNestGroups"]}`
-            : Config["tailwindNestGroups"],
-        Config["tailwind"],
-        Config["groupPrefix"] extends string
-            ? Config["groupPrefix"] | TAILWIND_IDENTIFIER
-            : TAILWIND_IDENTIFIER,
-        Config["useArbitrary"] extends boolean ? Config["useArbitrary"] : false
-    >
-    /**
-     * Enables arbitrary strings as valid style properties if `true`.
-     */
-    useArbitrary: Config["useArbitrary"]
-}
+export type CreateTailwindest<Config extends TailwindestConfig> = GetNestStyle<
+    Config["groupPrefix"] extends string
+        ? `${Config["groupPrefix"]}${Config["tailwindNestGroups"]}`
+        : Config["tailwindNestGroups"],
+    Config["tailwind"],
+    Config["groupPrefix"] extends string
+        ? Config["groupPrefix"] | TAILWIND_IDENTIFIER
+        : TAILWIND_IDENTIFIER,
+    Config["useArbitrary"] extends boolean ? Config["useArbitrary"] : false
+>
+
+/**
+ * Create tailwind literal typeset
+ *
+ * @description Run `npx create-tailwind-type` to generate tailwind type defs.
+ * ```bash
+ * npx create-tailwind-type --base node_modules/tailwindcss --no-arbitrary-value --disable-variants
+ * ```
+ * @see {@link https://github.com/danpacho/tailwindest#create-tailwind-type create-tailwind-type}
+ *
+ * @example
+ * ```ts
+ * // 1. import generated types
+ * import type { Tailwind, TailwindNestGroups } from "~/tailwind.ts"
+ *
+ * // 2. create type
+ * export type TailwindLiteral = CreateTailwindLiteral<Tailwind>
+ * ```
+ */
+export type CreateTailwindLiteral<Tailwind> = Tailwind[keyof Tailwind]

--- a/packages/tailwindest/src/index.ts
+++ b/packages/tailwindest/src/index.ts
@@ -1,5 +1,4 @@
 import { createTools, type GetVariants } from "./tools"
-import { CreateTailwindest } from "./create_tailwindest"
 
 // Merger public interfaces
 export type { Merger as TailwindestMerger } from "./tools/merger_interface"
@@ -10,4 +9,18 @@ export type { Tailwindest } from "./legacy/tailwindest"
 export type { ShortTailwindest } from "./legacy/tailwindest.short"
 
 // V3 + tailwindcss >= 4.0
-export { createTools, type GetVariants, type CreateTailwindest }
+export type {
+    CreateTailwindest,
+    CreateTailwindLiteral,
+} from "./create_tailwindest"
+
+// Export styler interfaces
+export type {
+    Styler,
+    PrimitiveStyler,
+    RotaryStyler,
+    ToggleStyler,
+    VariantsStyler,
+} from "./tools"
+
+export { createTools, type GetVariants }

--- a/packages/tailwindest/src/tools/__tests__/merger_interface.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/merger_interface.test.ts
@@ -1,4 +1,3 @@
-import { expectType, TypeEqual } from "ts-expect"
 import { describe, expect, it } from "vitest"
 import { twMerge } from "tailwind-merge"
 import { Merger } from "../merger_interface"
@@ -9,13 +8,13 @@ import { ClassList } from "../to_class"
 describe("Merger interface", () => {
     it("1. tailwind-merge", () => {
         const merger: Merger = twMerge
-        const t = createTools<
-            CreateTailwindest<{
+        const t = createTools<{
+            tailwindest: CreateTailwindest<{
                 tailwind: Record<string, any>
                 tailwindNestGroups: ""
                 useArbitrary: true
             }>
-        >({
+        }>({
             merger: merger,
         })
 
@@ -47,13 +46,13 @@ describe("Merger interface", () => {
             return res
         }
 
-        const t = createTools<
-            CreateTailwindest<{
+        const t = createTools<{
+            tailwindest: CreateTailwindest<{
                 tailwind: Record<string, any>
                 tailwindNestGroups: ""
                 useArbitrary: true
             }>
-        >({
+        }>({
             merger: customMerger,
         })
 

--- a/packages/tailwindest/src/tools/index.ts
+++ b/packages/tailwindest/src/tools/index.ts
@@ -1,2 +1,7 @@
 export * from "./create_tools"
 export * from "./get_variants"
+export * from "./styler"
+export * from "./primitive"
+export * from "./rotary"
+export * from "./toggle"
+export * from "./variants"

--- a/packages/tailwindest/src/tools/styler.ts
+++ b/packages/tailwindest/src/tools/styler.ts
@@ -15,8 +15,10 @@ export abstract class Styler<Args, Out> {
      * const tw = createTools<Tailwindest>({ merger: twMerge })
      * ```
      */
-    public setMerger(merger: Merger): void {
+    public setMerger(merger: Merger | undefined) {
+        if (!merger) return this
         this._merger = merger
+        return this
     }
     private _merger: Merger | null = null
     public get merger(): Merger {


### PR DESCRIPTION
## Description

Error occurs when building `.d.ts` files based on `tailwindest` project.

- `TS7056` : error occurs for maximum depth exceeding.
- `TS4094`:  error occurs for exported anonymous class type may not be private or protected.

This can be modified via
- Explicit alias based type injection.
- Export referenced classes for factory function.

### API Changes

`createTools` generic parameter

```ts
import {
    createTools,
    type CreateTailwindest,
    type CreateTailwindLiteral,
} from "tailwindest"

import type { Tailwind, TailwindNestGroups } from "./tailwind"

export type Tailwindest = CreateTailwindest<{
    tailwind: Tailwind
    tailwindNestGroups: TailwindNestGroups
    groupPrefix: "$" // prefix for nest groups, [optional]
    useArbitrary: true // enable arbitrary values, [optional]
}>
export type TailwindLiteral = CreateTailwindLiteral<Tailwind>

export const tw = createTools<{
    tailwindest: Tailwindest
    tailwindLiteral: TailwindLiteral
    useArbitrary: true // enable arbitrary values, [optional]
}>()
```

From `3.2.0`, generic parameter should be passed explicitly like below.

```ts
{
    tailwindest: Tailwindest
    tailwindLiteral: TailwindLiteral
    useArbitrary: true // enable arbitrary values, [optional]
}
```


## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [x] Breaking API Changes
-   [x] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
