### PR TITLE
[bug + feature] override variants base when `compose`, add multiple class literal for `class`

### DIFF
--- a/packages/tailwindest/src/create_tailwindest.ts
+++ b/packages/tailwindest/src/create_tailwindest.ts
@@ -88,6 +88,10 @@ export interface TailwindestInterface {
      * Enables arbitrary strings as valid style properties if `true`.
      */
     useArbitrary?: true | false
+    /**
+     * Use typed class literal strings for extra classes
+     */
+    useTypedClassLiteral?: true | false
 }
 
 /**
@@ -109,7 +113,8 @@ export interface TailwindestInterface {
  *      tailwind: Tailwind
  *      tailwindNestGroups: TailwindNestGroups
  *      useArbitrary: true
- *      groupPrefix: "#"
+ *      useTypedClassLiteral: true
+ *      groupPrefix: "#" // optional
  * }>
  * ```
  */

--- a/packages/tailwindest/src/index.ts
+++ b/packages/tailwindest/src/index.ts
@@ -1,14 +1,16 @@
 import { createTools, type GetVariants } from "./tools"
 
-// Merger public interfaces
-export type { Merger as TailwindestMerger } from "./tools/merger_interface"
-export type { ClassList as TailwindestClassList } from "./tools/to_class"
-
 // V2 + tailwindcss < 4.0
 export type { Tailwindest } from "./legacy/tailwindest"
 export type { ShortTailwindest } from "./legacy/tailwindest.short"
 
 // V3 + tailwindcss >= 4.0
+
+// Merger public interfaces
+export type { Merger as TailwindestMerger } from "./tools/merger_interface"
+export type { ClassList as TailwindestClassList } from "./tools/to_class"
+
+// Create tailwindest typeset
 export type {
     CreateTailwindest,
     CreateTailwindLiteral,

--- a/packages/tailwindest/src/tools/__tests__/create_tools.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/create_tools.test.ts
@@ -26,7 +26,13 @@ describe("PrimitiveStyler", () => {
         it("concatenates with extra class name", () => {
             const style: TestStyle = { color: "green" }
             const styler = new PrimitiveStyler<TestStyle>(style)
-            expect(styler.class("extra")).toBe("green extra")
+            expect(
+                styler.class(
+                    "extra1 extra2 extra3",
+                    ["extra4 extra5", "extra6"],
+                    "extra7"
+                )
+            ).toBe("green extra1 extra2 extra3 extra4 extra5 extra6 extra7")
         })
     })
 
@@ -144,7 +150,7 @@ describe("RotaryStyler", () => {
 
     describe("compose method", () => {
         it("creates new styler with composed base", () => {
-            const base: TestStyle = { color: "gray" }
+            const base: TestStyle = { color: "gray", fontSize: "14" }
             const variants: Record<VariantKey, TestStyle> = {
                 primary: { color: "blue" },
                 secondary: { color: "green" },
@@ -153,14 +159,14 @@ describe("RotaryStyler", () => {
                 base,
                 variants,
             })
-            const newStyler = styler.compose({ fontSize: "12", color: "gray" })
+            const newStyler = styler.compose({ color: "gray", fontSize: "200" })
             expect(newStyler.style("base")).toEqual({
                 color: "gray",
-                fontSize: "12",
+                fontSize: "200",
             })
             expect(newStyler.style("primary")).toEqual({
                 color: "blue",
-                fontSize: "12",
+                fontSize: "200",
             })
         })
     })

--- a/packages/tailwindest/src/tools/__tests__/get_variants.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/get_variants.test.ts
@@ -87,7 +87,7 @@ describe("GetVariants - rotary", () => {
 describe("GetVariants - style", () => {
     test("infer never", () => {
         const baseWind = tw.style({})
-        expectType<TypeEqual<GetVariants<typeof baseWind>, string | undefined>>(
+        expectType<TypeEqual<GetVariants<typeof baseWind>, string | string[]>>(
             true
         )
     })

--- a/packages/tailwindest/src/tools/__tests__/merger_interface.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/merger_interface.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { twMerge } from "tailwind-merge"
-import { Merger } from "../merger_interface"
 import { createTools } from "../create_tools"
-import { CreateTailwindest } from "../../create_tailwindest"
-import { ClassList } from "../to_class"
+import type { Merger } from "../merger_interface"
+import type { CreateTailwindest } from "../../create_tailwindest"
+
+import { twMerge } from "tailwind-merge"
 
 describe("Merger interface", () => {
     it("1. tailwind-merge", () => {
@@ -25,25 +25,23 @@ describe("Merger interface", () => {
             ["bg-red-100", "bg-red-200", "p-2"],
             {
                 backgroundColor: "bg-red-300",
+                border: ["border-t-4"],
+            },
+            {
+                border: "border-2",
             }
         )
-        expect(argumentOrderHasPriority).toBe("p-2 bg-red-300")
+        expect(argumentOrderHasPriority).toBe("p-2 bg-red-300 border-2")
+        const style = t.style({
+            backgroundColor: "bg-red-100",
+        })
+
+        expect(style.class("bg-red-200", "p-2")).toBe("bg-red-200 p-2")
     })
     it("2. custom-merger", () => {
-        const customMerger: Merger<ClassList> = (...args) => {
-            const res = args
-                .map((e) => {
-                    if (typeof e === "string") {
-                        return e
-                    }
-                    if (Array.isArray(e)) {
-                        return customMerger(...e)
-                    }
-                    throw new Error("Invalid merging value")
-                })
-                .filter(Boolean)
-                .join(" with ")
-            return res
+        const customMerger: Merger = (...args) => {
+            const uniqueToken = Array.from(new Set(args))
+            return uniqueToken.join(" with ")
         }
 
         const t = createTools<{
@@ -59,11 +57,14 @@ describe("Merger interface", () => {
         const style1 = t.def([["bg-red-100", "bg-red-200"], "p-2"])
         expect(style1).toBe("bg-red-100 with bg-red-200 with p-2")
 
-        const style2 = t.def(["bg-red-100", "bg-red-200", "p-2"], {
-            backgroundColor: "bg-red-300",
-        })
+        const style2 = t.def(
+            ["bg-red-100", "ONCE", "ONCE", "ONCE", "bg-red-200", "p-2"],
+            {
+                backgroundColor: "bg-red-300",
+            }
+        )
         expect(style2).toBe(
-            "bg-red-100 with bg-red-200 with p-2 with bg-red-300"
+            "bg-red-100 with ONCE with bg-red-200 with p-2 with bg-red-300"
         )
     })
 })

--- a/packages/tailwindest/src/tools/__tests__/styler.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/styler.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { Styler } from "../styler" // Adjust path as needed
-import type { Merger } from "../merger_interface"
+import type { AdditionalClassTokens, Merger } from "../merger_interface"
 
 // Mock implementation of Styler for testing abstract methods
 class TestStyler extends Styler<string, Record<string, unknown>> {
-    public class(key: string, extraClassName?: string): string {
-        return this.merger(key, extraClassName || "")
+    public class(
+        key: string,
+        ...extraClassNames: AdditionalClassTokens<string>
+    ): string {
+        return this.merge(key, ...extraClassNames)
     }
 
     public style(key: string, extraStyle?: Record<string, unknown>): unknown {
@@ -21,7 +24,9 @@ describe("Styler", () => {
     describe("merger", () => {
         it("uses default merger when none set", () => {
             const styler = new TestStyler()
-            expect(styler.merger("a", "b")).toBe("a b")
+            expect(styler.merge("a", "b", ["d e f", "g", "h"], "i")).toBe(
+                "a b d e f g h i"
+            )
         })
 
         it("uses custom merger when set", () => {
@@ -30,7 +35,7 @@ describe("Styler", () => {
                 classes.join("-")
             )
             styler.setMerger(customMerger)
-            expect(styler.merger("a", "b")).toBe("a-b")
+            expect(styler.merge("a", "b")).toBe("a-b")
             expect(customMerger).toHaveBeenCalledWith("a", "b")
         })
     })

--- a/packages/tailwindest/src/tools/create_tools.ts
+++ b/packages/tailwindest/src/tools/create_tools.ts
@@ -111,8 +111,17 @@ export const createTools = <Type extends TailwindestInterface>({
         return res
     }
 
-    const join = (...classList: ClassList<ClassLiteral>): string =>
-        merger ? merger(...toClass(classList).split(" ")) : toClass(classList)
+    const join = (...classList: ClassList<ClassLiteral>): string => {
+        if (merger) {
+            const classListStr = toClass(classList)
+            const tokens = classListStr
+                .split(" ")
+                .filter((e) => e.length > 0)
+                .map((e) => e.trim())
+            return merger(...tokens)
+        }
+        return toClass(classList)
+    }
 
     const def = (
         classList: ClassList<ClassLiteral>,

--- a/packages/tailwindest/src/tools/create_tools.ts
+++ b/packages/tailwindest/src/tools/create_tools.ts
@@ -131,6 +131,9 @@ export const createTools = <Type extends TailwindestInterface>({
     return {
         /**
          * Define style
+         *
+         * `styleList` has higher priority than `classList`
+         *
          * @see {@link https://github.com/lukeed/clsx#readme clsx}
          * @param classList join target styles
          * @param styleList define styles in a record structure way

--- a/packages/tailwindest/src/tools/get_variants.ts
+++ b/packages/tailwindest/src/tools/get_variants.ts
@@ -3,8 +3,8 @@ import type { Styler } from "./styler"
 /**
  * Get variants
  */
-export type GetVariants<StylerInstance extends Styler<any, any>> =
-    StylerInstance extends Styler<infer Arg, any>
+export type GetVariants<StylerInstance extends Styler<any, any, any>> =
+    StylerInstance extends Styler<infer Arg, any, any>
         ? Arg extends never
             ? never
             : Exclude<Parameters<StylerInstance["class"]>[0], "base">

--- a/packages/tailwindest/src/tools/merger_interface.ts
+++ b/packages/tailwindest/src/tools/merger_interface.ts
@@ -1,7 +1,14 @@
 /**
  * @interface
+ * Additional class tokens that can be merged into a single className string.
+ */
+export type AdditionalClassTokens<Literal extends string> = Array<
+    Literal | Array<Literal>
+>
+/**
+ * @interface
  * Merge arbitrary class list into one valid style classname string
  */
-export type Merger<ClassList extends Array<any> = any[]> = (
-    ...classList: ClassList
+export type Merger<Literal extends string = string> = (
+    ...classList: AdditionalClassTokens<Literal>
 ) => string

--- a/packages/tailwindest/src/tools/primitive.ts
+++ b/packages/tailwindest/src/tools/primitive.ts
@@ -1,6 +1,10 @@
+import type { AdditionalClassTokens } from "./merger_interface"
 import { Styler } from "./styler"
 
-export class PrimitiveStyler<StyleType> extends Styler<never, StyleType> {
+export class PrimitiveStyler<
+    StyleType,
+    StyleLiteral extends string = string,
+> extends Styler<never, StyleType, StyleLiteral> {
     private _class: string
     private _style: StyleType
 
@@ -14,20 +18,22 @@ export class PrimitiveStyler<StyleType> extends Styler<never, StyleType> {
      * Get classname
      * @param extraClassName extra classnames, if merger is provided it uses merger or just concat.
      */
-    public class(extraClassName?: string): string {
+    public class(
+        ...extraClassList: AdditionalClassTokens<StyleLiteral>
+    ): string {
         const inquired = this._class
-        if (!extraClassName) return inquired
-        return this.merger(inquired, extraClassName)
+        if (!extraClassList) return inquired
+        return this.merge(inquired as StyleLiteral, ...extraClassList)
     }
 
     /**
      * Get stylesheet
      * @param extraStyle extra stylesheet
      */
-    public style(extraStyle?: StyleType): StyleType {
+    public style(...extraStyles: Array<StyleType>): StyleType {
         const inquired = this._style
-        if (!extraStyle) return inquired
-        return Styler.deepMerge(inquired, extraStyle)
+        if (!extraStyles) return inquired
+        return Styler.deepMerge(inquired, ...extraStyles)
     }
 
     public compose(...styles: Array<StyleType>): PrimitiveStyler<StyleType> {

--- a/packages/tailwindest/src/tools/rotary.ts
+++ b/packages/tailwindest/src/tools/rotary.ts
@@ -1,21 +1,20 @@
+import type { AdditionalClassTokens } from "./merger_interface"
 import { Styler } from "./styler"
 
 export class RotaryStyler<
     StyleType,
     const VariantKey extends string,
-> extends Styler<VariantKey, StyleType> {
+    StyleLiteral extends string = string,
+> extends Styler<VariantKey, StyleType, StyleLiteral> {
     private _variants: Record<VariantKey | "base", StyleType>
+    private _originalVariants: Record<VariantKey, StyleType>
     private _variantsMap: Record<VariantKey | "base", string>
 
-    public constructor({
-        variants,
-        base = {} as StyleType,
-    }: {
-        base?: StyleType | undefined
-        variants: Record<VariantKey, StyleType>
-    }) {
-        super()
-        this._variants = Object.entries(variants).reduce<
+    private _createVariants(
+        variants: Record<VariantKey, StyleType>,
+        base: StyleType = {} as StyleType
+    ): Record<VariantKey | "base", StyleType> {
+        return Object.entries(variants).reduce<
             Record<VariantKey | "base", StyleType>
         >(
             (variants, [key, value]) => {
@@ -23,15 +22,20 @@ export class RotaryStyler<
                     return variants
                 }
                 variants[key as VariantKey] = Styler.deepMerge<StyleType>(
-                    variants["base"],
+                    base,
                     value as StyleType
                 )
                 return variants
             },
             { base: base } as Record<VariantKey | "base", StyleType>
         )
-        this._variantsMap = {
-            ...Object.entries(this._variants).reduce<
+    }
+    private _createVariantsMap(
+        variants: Record<VariantKey | "base", StyleType>,
+        base: StyleType = {} as StyleType
+    ): Record<VariantKey | "base", string> {
+        return {
+            ...Object.entries(variants).reduce<
                 Record<VariantKey | "base", string>
             >(
                 (variantsMap, [key, value]) => {
@@ -43,35 +47,47 @@ export class RotaryStyler<
             base: Styler.getClassName(base),
         }
     }
+    public constructor({
+        variants,
+        base = {} as StyleType,
+    }: {
+        base?: StyleType | undefined
+        variants: Record<VariantKey, StyleType>
+    }) {
+        super()
+        this._originalVariants = variants
+        this._variants = this._createVariants(variants, base)
+        this._variantsMap = this._createVariantsMap(this._variants, base)
+    }
 
     /**
      * Get stylesheet
      * @param variant variant name
-     * @param extraStyle extra stylesheet
+     * @param extraStyles extra stylesheet
      */
     public style(
         variant?: VariantKey | "base",
-        extraStyle?: StyleType
+        ...extraStyles: Array<StyleType>
     ): StyleType {
         const inquired = this._variants[variant as VariantKey]
 
-        if (!extraStyle) return inquired
-        return Styler.deepMerge(inquired, extraStyle)
+        if (!extraStyles) return inquired
+        return Styler.deepMerge(inquired, ...extraStyles)
     }
 
     /**
      * Get classname
      * @param variant variant name
-     * @param extraClassName extra classnames, if merger is provided it uses merger or just concat.
+     * @param extraClassNames extra classnames, if merger is provided it uses merger or just concat.
      */
     public class(
         variant: VariantKey | "base",
-        extraClassName?: string
+        ...extraClassNames: AdditionalClassTokens<StyleLiteral>
     ): string {
         const inquired = this._variantsMap[variant]
 
-        if (!extraClassName) return inquired
-        return this.merger(inquired, extraClassName)
+        if (!extraClassNames) return inquired
+        return this.merge(inquired as StyleLiteral, ...extraClassNames)
     }
 
     public compose(
@@ -79,10 +95,9 @@ export class RotaryStyler<
     ): RotaryStyler<StyleType, VariantKey> {
         const baseStyle = this.style("base")
         const composedStyle = Styler.deepMerge(baseStyle, ...styles)
-
         return new RotaryStyler({
             base: composedStyle,
-            variants: this._variants,
+            variants: this._originalVariants,
         })
     }
 }

--- a/packages/tailwindest/src/tools/styler.ts
+++ b/packages/tailwindest/src/tools/styler.ts
@@ -33,6 +33,7 @@ export abstract class Styler<Args, Out, Literal extends string = string> {
                 Array.isArray(token) ? token : token.split(" ")
             )
             .filter((token) => token && token.length > 0)
+            .map((token) => token.trim())
 
         return this._merger
             ? this._merger(...tokens)

--- a/packages/tailwindest/src/tools/to_class.ts
+++ b/packages/tailwindest/src/tools/to_class.ts
@@ -1,7 +1,7 @@
 import { clsx } from "clsx"
 
 // Type definition from <clsx> copyright >> https://github.com/lukeed/clsx
-type ClassValue<Literal extends string = string> =
+type ClassValue<Literal> =
     | ClassList<Literal>
     | ClassDictionary
     | Literal
@@ -16,10 +16,8 @@ type ClassDictionary = Record<string, any>
  * @interface
  * Default supported class list
  */
-export type ClassList<Literal extends string = string> = ClassValue<Literal>[]
+export type ClassList<Literal = any> = ClassValue<Literal>[]
 
-export function toClass<Literal extends string = string>(
-    ...classList: ClassList<Literal>
-): string {
+export function toClass<Literal>(...classList: ClassList<Literal>): string {
     return clsx(classList)
 }

--- a/packages/tailwindest/src/tools/to_def.ts
+++ b/packages/tailwindest/src/tools/to_def.ts
@@ -6,7 +6,5 @@ export function toDef<StyleType>(
     styleMerger: (...styles: Array<StyleType>) => string,
     join: (...classList: ClassList<string>) => string
 ): string {
-    const classLiteral = join(...classList)
-    const styleLiteral = styleMerger(...styleList)
-    return join(classLiteral, styleLiteral)
+    return join(...classList, styleMerger(...styleList))
 }

--- a/packages/tailwindest/src/tools/toggle.ts
+++ b/packages/tailwindest/src/tools/toggle.ts
@@ -1,3 +1,4 @@
+import type { AdditionalClassTokens } from "./merger_interface"
 import { RotaryStyler } from "./rotary"
 import { Styler } from "./styler"
 
@@ -16,11 +17,14 @@ export type ToggleVariants<StyleType> = {
     falsy: StyleType
 }
 
-export class ToggleStyler<StyleType> extends Styler<boolean, StyleType> {
-    private _rotary: RotaryStyler<StyleType, "T" | "F">
+export class ToggleStyler<
+    StyleType,
+    StyleLiteral extends string = string,
+> extends Styler<boolean, StyleType, StyleLiteral> {
+    private _rotary: RotaryStyler<StyleType, "T" | "F", StyleLiteral>
     public constructor(toggle: ToggleVariants<StyleType>) {
         super()
-        this._rotary = new RotaryStyler<StyleType, "T" | "F">({
+        this._rotary = new RotaryStyler<StyleType, "T" | "F", StyleLiteral>({
             base: toggle.base,
             variants: {
                 T: toggle.truthy,
@@ -32,12 +36,15 @@ export class ToggleStyler<StyleType> extends Styler<boolean, StyleType> {
     /**
      * Get classname
      * @param condition toggle condition
-     * @param extraClassName extra classnames, if merger is provided it uses merger or just concat.
+     * @param extraClassNames extra classnames, if merger is provided it uses merger or just concat.
      */
-    public class(condition: boolean, extraClass?: string): string {
+    public class(
+        condition: boolean,
+        ...extraClassNames: AdditionalClassTokens<StyleLiteral>
+    ): string {
         const inquired = this._rotary.class(condition ? "T" : "F")
-        if (!extraClass) return inquired
-        return this.merger(inquired, extraClass)
+        if (!extraClassNames) return inquired
+        return this.merge(inquired as StyleLiteral, ...extraClassNames)
     }
 
     /**

--- a/packages/tailwindest/src/tools/variants.ts
+++ b/packages/tailwindest/src/tools/variants.ts
@@ -1,5 +1,6 @@
 import { Styler } from "./styler"
 import { RotaryStyler } from "./rotary"
+import type { AdditionalClassTokens } from "./merger_interface"
 
 export type VariantsRecord<StyleType> = Record<
     string,
@@ -20,7 +21,8 @@ type VariantStylerMap<
 export class VariantsStyler<
     StyleType,
     const VMap extends VariantsRecord<StyleType>,
-> extends Styler<VariantOptions<VMap>, StyleType> {
+    StyleLiteral extends string = string,
+> extends Styler<VariantOptions<VMap>, StyleType, StyleLiteral> {
     private _base: StyleType
     private _variantsMap: VMap
     private _variantStylerMap: VariantStylerMap<StyleType, keyof VMap>
@@ -51,7 +53,7 @@ export class VariantsStyler<
      */
     public style(
         variant: VariantOptions<VMap>,
-        extraStyle?: StyleType
+        ...extraStyles: Array<StyleType>
     ): StyleType {
         let merged = this._base
 
@@ -64,8 +66,8 @@ export class VariantsStyler<
             }
         }
 
-        if (!extraStyle) return merged
-        return Styler.deepMerge(merged, extraStyle)
+        if (!extraStyles) return merged
+        return Styler.deepMerge(merged, ...extraStyles)
     }
 
     /**
@@ -75,12 +77,12 @@ export class VariantsStyler<
      */
     public class(
         variant: VariantOptions<VMap>,
-        extraClassName?: string
+        ...extraClassName: AdditionalClassTokens<StyleLiteral>
     ): string {
         const inquired = this.style(variant)
-
-        if (!extraClassName) return Styler.getClassName(inquired)
-        return this.merger(...Styler.flattenRecord(inquired), extraClassName)
+        const className = Styler.getClassName(inquired)
+        if (!extraClassName) return className
+        return this.merge(className as StyleLiteral, ...extraClassName)
     }
 
     public compose(


### PR DESCRIPTION
## Description

- Fix `rotary.compose` function's base style overriding logic.

   ```ts
   const btn1 = tw.rotary({
       variants: { 
           warning: {...}
       },
       base: {
           fontSize: 'text-xs'
       },
   })

   const btn2 = btn.compose({
        fontSize: 'text-xl' // change base font size to xl
   })

   const res1 = btn1.class("warning") // text-xs ...
   const res2 = btn2.class("warning") // text-xl ...
   ``` 
- Support add `class` method's multiple extra classes.
 
   ```ts
   const base = tw.style({...})
   
   const withExtra = base.class("c1", "c2", ["c3", "c4"], "c5") // ... c1 c2 c3 c4 c5
   ``` 
- Support statically typed className strings for `class` method's extra classes.

   ```ts
     import type { Tailwind, TailwindNestGroups } from "~/tailwind.ts"

     export type Tailwindest = CreateTailwindest<{
          tailwind: Tailwind
          tailwindNestGroups: TailwindNestGroups
          useArbitrary: true
     }>
     export type TailwindLiteral = CreateTailwindLiteral<Tailwind>

     export const tw = createTools<{
          tailwindest: Tailwindest
          tailwindLiteral: TailwindLiteral
          useArbitrary: true  // enable arbitrary strings
          useTypedClassLiteral: true // ✅ enable typed class literal <-- [added]
     >()

   // now, extra classes arguments are fully typed.
   const box = tw.style({...}).class("bg-red-100") // ✅ <-- statically typed
   ``` 

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [x] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
