### PR TITLE
164 bug toggle styler compose method preserve issue

### DIFF
--- a/packages/tailwindest/CHANGELOG.md
+++ b/packages/tailwindest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # tailwindest
 
+## 3.2.2
+
+### Patch Changes
+
+- Fix rotary.compose method invalid overriding error
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/tailwindest/package.json
+++ b/packages/tailwindest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tailwindest",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "description": "typesafe, reusable tailwind",
     "homepage": "https://tailwindest.vercel.app",
     "author": "danpacho",

--- a/packages/tailwindest/src/tools/__tests__/compose.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/compose.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest"
+import { createTools } from "../create_tools"
+
+const tw = createTools()
+
+describe("compose method in complex scenarios", () => {
+    it("should handle multiple compositions on PrimitiveStyler", () => {
+        const primitive = tw.style({
+            color: "red",
+            fontSize: "12px",
+        })
+
+        const composed1 = primitive.compose({ color: "blue" })
+        const composed2 = composed1.compose({ fontSize: "16px" })
+        const composed3 = composed2.compose({ fontWeight: "bold" })
+
+        expect(composed1.style()).toEqual({
+            color: "blue",
+            fontSize: "12px",
+        })
+        expect(composed2.style()).toEqual({
+            color: "blue",
+            fontSize: "16px",
+        })
+        expect(composed3.style()).toEqual({
+            color: "blue",
+            fontSize: "16px",
+            fontWeight: "bold",
+        })
+    })
+
+    it("should handle multiple compositions on ToggleStyler", () => {
+        const toggle = tw.toggle({
+            base: { color: "gray" },
+            truthy: { color: "green" },
+            falsy: { color: "red" },
+        })
+
+        const composed1 = toggle.compose({ backgroundColor: "white" })
+        const composed2 = composed1.compose({ padding: "10px" })
+        const composed3 = composed2.compose({
+            color: "black",
+        })
+
+        expect(composed1.style(true)).toEqual({
+            color: "green",
+            backgroundColor: "white",
+        })
+        expect(composed2.style(false)).toEqual({
+            color: "red",
+            backgroundColor: "white",
+            padding: "10px",
+        })
+        expect(composed3.style(true)).toEqual({
+            color: "green",
+            backgroundColor: "white",
+            padding: "10px",
+        })
+    })
+
+    it("should handle multiple compositions on RotaryStyler", () => {
+        const rotary = tw.rotary({
+            base: { fontSize: "14px" },
+            variants: {
+                primary: { color: "blue" },
+                secondary: { color: "green" },
+            },
+        })
+
+        const composed1 = rotary.compose({ fontWeight: "bold" })
+        const composed2 = composed1.compose({ fontSize: "18px" })
+        const composed3 = composed2.compose({
+            color: "purple",
+        })
+
+        expect(composed1.style("primary")).toEqual({
+            fontSize: "14px",
+            color: "blue",
+            fontWeight: "bold",
+        })
+        expect(composed2.style("secondary")).toEqual({
+            fontSize: "18px",
+            color: "green",
+            fontWeight: "bold",
+        })
+        expect(composed3.style("primary")).toEqual({
+            fontSize: "18px",
+            color: "blue",
+            fontWeight: "bold",
+        })
+    })
+
+    it("should handle multiple compositions on VariantsStyler", () => {
+        const variants = tw.variants({
+            base: { display: "flex" },
+            variants: {
+                size: {
+                    small: { fontSize: "12px" },
+                    large: { fontSize: "20px" },
+                },
+                color: {
+                    light: { color: "white" },
+                    dark: { color: "black" },
+                },
+            },
+        })
+
+        const composed1 = variants.compose({ alignItems: "center" })
+        const composed2 = composed1.compose({
+            display: "inline-flex",
+        })
+        const composed3 = composed2.compose({
+            fontSize: "16px",
+        })
+
+        expect(composed1.style({ size: "small", color: "dark" })).toEqual({
+            display: "flex",
+            fontSize: "12px",
+            color: "black",
+            alignItems: "center",
+        })
+        expect(composed2.style({ size: "large", color: "light" })).toEqual({
+            display: "inline-flex",
+            fontSize: "20px",
+            color: "white",
+            alignItems: "center",
+        })
+        expect(composed3.style({ size: "small" })).toEqual({
+            display: "inline-flex",
+            fontSize: "12px",
+            alignItems: "center",
+        })
+    })
+
+    it("should correctly override styles with subsequent compositions", () => {
+        const primitive = tw.style({
+            padding: "10px",
+            margin: "10px",
+        })
+
+        const composed = primitive
+            .compose({ padding: "12px" })
+            .compose({ padding: "14px" })
+            .compose({ padding: "16px" })
+
+        expect(composed.style()).toEqual({
+            padding: "16px",
+            margin: "10px",
+        })
+    })
+
+    it("should maintain original variants after composition", () => {
+        const rotary = tw.rotary({
+            variants: {
+                one: { color: "one" },
+                two: { color: "two" },
+            },
+        })
+
+        const composed = rotary.compose({ background: "bg" })
+
+        expect(composed.style("one")).toEqual({
+            color: "one",
+            background: "bg",
+        })
+        expect(composed.style("two")).toEqual({
+            color: "two",
+            background: "bg",
+        })
+    })
+})

--- a/packages/tailwindest/src/tools/__tests__/create_tools.test.ts
+++ b/packages/tailwindest/src/tools/__tests__/create_tools.test.ts
@@ -243,15 +243,21 @@ describe("ToggleStyler", () => {
                 truthy: { color: "blue" },
                 falsy: { color: "green" },
             }
+            const other = new PrimitiveStyler<TestStyle>({
+                color: "OTHER",
+                fontSize: "OTHER",
+            })
             const styler = new ToggleStyler<TestStyle>(toggle)
-            const newStyler = styler.compose({ fontSize: "12", color: "gray" })
+            const newStyler = styler
+                .compose({ fontSize: "12", color: "gray" })
+                .compose(other.style())
             expect(newStyler.style(true)).toEqual({
                 color: "blue",
-                fontSize: "12",
+                fontSize: "OTHER",
             })
             expect(newStyler.style(false)).toEqual({
                 color: "green",
-                fontSize: "12",
+                fontSize: "OTHER",
             })
         })
     })

--- a/packages/tailwindest/src/tools/toggle.ts
+++ b/packages/tailwindest/src/tools/toggle.ts
@@ -22,8 +22,13 @@ export class ToggleStyler<
     StyleLiteral extends string = string,
 > extends Styler<boolean, StyleType, StyleLiteral> {
     private _rotary: RotaryStyler<StyleType, "T" | "F", StyleLiteral>
+    private _T: StyleType
+    private _F: StyleType
+
     public constructor(toggle: ToggleVariants<StyleType>) {
         super()
+        this._T = toggle.truthy
+        this._F = toggle.falsy
         this._rotary = new RotaryStyler<StyleType, "T" | "F", StyleLiteral>({
             base: toggle.base,
             variants: {
@@ -65,8 +70,8 @@ export class ToggleStyler<
         )
         return new ToggleStyler({
             base: mergedBase,
-            truthy: this._rotary.style("T"),
-            falsy: this._rotary.style("F"),
+            truthy: this._T,
+            falsy: this._F,
         })
     }
 }


### PR DESCRIPTION
## Description

`tools.rotary`'s `compose` method does not correctly handle merging behavior. It disappears original T/F property when return new instance using `compose`. 

Now these `compose` tests are passed correctly. 

```ts
    it("should handle multiple compositions on ToggleStyler", () => {
        const toggle = tw.toggle({
            base: { color: "gray" },
            truthy: { color: "green" },
            falsy: { color: "red" },
        })

        const composed1 = toggle.compose({ backgroundColor: "white" })
        const composed2 = composed1.compose({ padding: "10px" })
        const composed3 = composed2.compose({
            color: "black",
        })

        expect(composed1.style(true)).toEqual({
            color: "green",
            backgroundColor: "white",
        })
        expect(composed2.style(false)).toEqual({
            color: "red",
            backgroundColor: "white",
            padding: "10px",
        })
        expect(composed3.style(true)).toEqual({
            color: "green",
            backgroundColor: "white",
            padding: "10px",
        })
    })
```

## Type of Change

-   [x] Bug Fix
-   [ ] Enhancement
-   [ ] Breaking API Changes
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (please describe)

## Checklist

-   [x] I have verified this change is not present in other open pull requests
-   [x] Existing issues have been referenced (where applicable)
-   [x] Functionality is documented
-   [x] All code style checks pass
-   [x] All new and existing tests pass
